### PR TITLE
[FE] feat: 글 생성 API 연결

### DIFF
--- a/frontend/src/apis/writings.ts
+++ b/frontend/src/apis/writings.ts
@@ -7,7 +7,7 @@ const writingURL = `${baseURL}/writings`;
 // 글 생성(글 업로드): POST
 export const addWriting = (body: AddWritingRequest) =>
   http.post(`${writingURL}/file`, {
-    body: JSON.stringify(body),
+    body,
     headers: {
       'Content-Type': 'multipart/form-data',
     },

--- a/frontend/src/hooks/@common/useGetQuery.ts
+++ b/frontend/src/hooks/@common/useGetQuery.ts
@@ -14,11 +14,11 @@ export const useGetQuery = <ResponseData>({
   onSettled,
 }: UseGetQueryArgs<ResponseData>) => {
   const [data, setData] = useState<ResponseData | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
   const getData = useCallback(async () => {
-    setLoading(true);
+    setIsLoading(true);
     setError(null);
     try {
       const response = await fetcher();
@@ -42,7 +42,7 @@ export const useGetQuery = <ResponseData>({
       }
     } finally {
       onSettled?.();
-      setLoading(false);
+      setIsLoading(false);
     }
   }, [fetcher]);
 
@@ -52,7 +52,7 @@ export const useGetQuery = <ResponseData>({
 
   return {
     data,
-    loading,
+    isLoading,
     error,
     getData,
   };

--- a/frontend/src/hooks/@common/useMutation.ts
+++ b/frontend/src/hooks/@common/useMutation.ts
@@ -1,18 +1,18 @@
 import { useState } from 'react';
 
-type useMutateQueryArgs<RequestData, ResponseData> = {
+type useMutationArgs<RequestData, ResponseData> = {
   fetcher: (body: RequestData) => Promise<Response>;
   onSuccess?: (data: { response: ResponseData; headers: Headers }) => void;
   onError?: (error?: Error) => void;
   onSettled?: () => void;
 };
 
-const useMutateQuery = <RequestData, ResponseData>({
+const useMutation = <RequestData, ResponseData>({
   fetcher,
   onSuccess,
   onError,
   onSettled,
-}: useMutateQueryArgs<RequestData, ResponseData>) => {
+}: useMutationArgs<RequestData, ResponseData>) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -48,4 +48,4 @@ const useMutateQuery = <RequestData, ResponseData>({
 
   return { mutateQuery, isLoading, error };
 };
-export default useMutateQuery;
+export default useMutation;

--- a/frontend/src/hooks/@common/useMutationQuery.ts
+++ b/frontend/src/hooks/@common/useMutationQuery.ts
@@ -1,27 +1,27 @@
 import { useState } from 'react';
 
-interface useMutateQueryArgs<ResponseData> {
-  fetcher: () => Promise<Response>;
+type useMutateQueryArgs<RequestData, ResponseData> = {
+  fetcher: (body: RequestData) => Promise<Response>;
   onSuccess?: (data: { response: ResponseData; headers: Headers }) => void;
   onError?: (error?: Error) => void;
   onSettled?: () => void;
-}
+};
 
-const useMutateQuery = <ResponseData>({
+const useMutateQuery = <RequestData, ResponseData>({
   fetcher,
   onSuccess,
   onError,
   onSettled,
-}: useMutateQueryArgs<ResponseData>) => {
-  const [loading, setLoading] = useState(false);
+}: useMutateQueryArgs<RequestData, ResponseData>) => {
+  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  const mutateQuery = async () => {
-    setLoading(true);
+  const mutateQuery = async (body: RequestData) => {
+    setIsLoading(true);
     setError(null);
 
     try {
-      const response = await fetcher();
+      const response = await fetcher(body);
 
       if (!response.ok) {
         const { status, statusText } = response;
@@ -42,10 +42,10 @@ const useMutateQuery = <ResponseData>({
       }
     } finally {
       onSettled?.();
-      setLoading(false);
+      setIsLoading(false);
     }
   };
 
-  return { mutateQuery, loading, error };
+  return { mutateQuery, isLoading, error };
 };
 export default useMutateQuery;

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -1,19 +1,19 @@
+import { addWriting } from 'apis/writings';
 import { InputHTMLAttributes, useEffect, useState } from 'react';
+import { AddWritingRequest } from 'types/apis/writings';
+import useMutation from './@common/useMutation';
 
 export const useFileUpload = (accept: InputHTMLAttributes<HTMLInputElement>['accept'] = '*') => {
   const [selectedFile, setSelectedFile] = useState<FormData | null>(null);
+  const { mutateQuery } = useMutation<AddWritingRequest, null>({
+    fetcher: (body) => addWriting(body),
+  });
 
   const onFileChange = (e: Event) => {
     const target = e.target as HTMLInputElement;
     if (!target.files) return;
 
     const newFile = target.files[0];
-    const fileType = newFile.type;
-
-    if (!fileType.includes('md')) {
-      // TODO: 파일 타입 검증
-      return;
-    }
 
     const formData = new FormData();
     formData.append('file', newFile);
@@ -21,11 +21,10 @@ export const useFileUpload = (accept: InputHTMLAttributes<HTMLInputElement>['acc
     setSelectedFile(formData);
   };
 
-  const uploadOnServer = (selectedFile: FormData | null) => {
+  const uploadOnServer = async (selectedFile: FormData | null) => {
     if (!selectedFile) return;
 
-    // TODO: 파일 선택 시 서버에 업로드 하는 API 연결
-    console.log('upload', selectedFile);
+    await mutateQuery(selectedFile);
   };
 
   const openFinder = () => {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,14 +1,16 @@
+import { worker } from 'mocks/browser';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { ThemeProvider } from 'styled-components';
 
 import GlobalStyle from 'styles/GlobalStyle';
 import { theme } from 'styles/theme';
-import { worker } from 'mocks/browser';
 import App from './App';
 
 if (process.env.NODE_ENV === 'development') {
-  worker.start();
+  worker.start({
+    onUnhandledRequest: 'bypass',
+  });
 }
 
 const root = createRoot(document.getElementById('root') as HTMLElement);

--- a/frontend/src/types/apis/writings.ts
+++ b/frontend/src/types/apis/writings.ts
@@ -1,6 +1,4 @@
-export type AddWritingRequest = {
-  file: FormData;
-};
+export type AddWritingRequest = FormData;
 
 export type GetWritingResponse = {
   id: number;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -47,4 +47,5 @@ module.exports = {
     hot: true,
     open: true,
   },
+  devtool: 'source-map',
 };


### PR DESCRIPTION
### 🛠️ Issue

- close #15

### ✅ Tasks
- [x] devtool sourcemap 에러 해결
- [x] 핸들러에 추가되지 않은 요청 처리 에러 수정
- [x] addWriting API formData 그대로 전송되도록 수정
- [x] AddWritingRequest type 수정
- [x] useMutation으로 네이밍 변경
- [x] isLoading으로 state 명 변경
- [x] 글 생성 API 연결
- [x] body 데이터를 받을 수 있도록 useMutationQuery 수정

### ⏰ Time Difference
- 2(+0)

### 📝 Note
- 개발자 도구에 뜨는 에러들을 해결을 위해서 설정을 추가하였습니다.
  - 웹팩에 `devtool: sourcemap` 지정을 하지 않아서 sourcemap load를 할 수 없다고 뜨는 에러 해결
  - msw의 핸들러에 추가되어 있지 않은 요청 처리는 msw를 거치지 않고 그대로 처리하는 옵션 추가(`index.tsx`)
- `addWriting` API body 데이터 수정
  - `'Content-Type': 'multipart/form-data'`으로 해놔서 `json`형태가 아니라 `FormData`를 그대로 넘겨야해서 수정
  - `addWritingRequest` Type도 같이 수정
- `useMutation` 훅
  - 훅 이름 변경
  - query훅 `loading` -> `isLoading`으로 변경
- 글 생성 API 연결
  - 파일 타입 검사하는 부분은 삭제하였습니다. -> 서버에서 검사하기도 하고, 검사하는 로직이 조금 까다로움.
  - `useMutation` 훅을 사용하여 구현
  - mutateQuery에 body 데이터를 넣는 것이 필요해서 useMutation 훅을 약간 리팩토링(5af02520954d10f03f5f5b17477a4d29c220a58e)