### PR TITLE
[FE] feat: 글 정보 섹션 `WritingPropertySection` 구현

### DIFF
--- a/frontend/src/components/WritingPropertySection/WritingPropertySection.stories.tsx
+++ b/frontend/src/components/WritingPropertySection/WritingPropertySection.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StoryContainer } from 'styles/storybook';
+import WritingPropertySection from './WritingPropertySection';
+
+const meta: Meta<typeof WritingPropertySection> = {
+  title: 'publishing/WritingPropertySection',
+  component: WritingPropertySection,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  render: () => (
+    <StoryContainer>
+      <WritingPropertySection writingId={200} />
+    </StoryContainer>
+  ),
+};

--- a/frontend/src/components/WritingPropertySection/WritingPropertySection.tsx
+++ b/frontend/src/components/WritingPropertySection/WritingPropertySection.tsx
@@ -1,0 +1,141 @@
+import { Fragment, ReactElement } from 'react';
+import { getWritingProperties } from 'apis/writings';
+import { CalendarIcon, MediumLogoIcon, TagIcon, TistoryLogoIcon } from 'assets/icons';
+import Tag from 'components/@common/Tag/Tag';
+import { useGetQuery } from 'hooks/@common/useGetQuery';
+import { styled } from 'styled-components';
+import { GetWritingPropertiesResponse } from 'types/apis/writings';
+import { dateFormatter } from 'utils/date';
+import type { Blog } from 'types/domain';
+
+const blogIcon: Record<Blog, ReactElement> = {
+  MEDIUM: <MediumLogoIcon width='1.2rem' height='1.2rem' />,
+  TISTORY: <TistoryLogoIcon width='1.2rem' height='1.2rem' />,
+};
+
+type Props = {
+  writingId: number;
+};
+
+const WritingPropertySection = ({ writingId }: Props) => {
+  const { data: writingInfo } = useGetQuery<GetWritingPropertiesResponse>({
+    fetcher: () => getWritingProperties(writingId),
+  });
+
+  if (!writingInfo) return <></>;
+
+  return (
+    <S.WritingPropertySection>
+      <S.SectionHeader>Writing Info</S.SectionHeader>
+      <S.InfoList>
+        <S.Info>
+          <S.InfoHeader>PROPERTIES</S.InfoHeader>
+          <S.InfoContent>
+            <S.PropertyRow>
+              <S.PropertyName>
+                <CalendarIcon width={12} height={12} />
+                Created
+              </S.PropertyName>
+              <S.PropertyValue>
+                {dateFormatter(writingInfo.createdAt, 'YYYY/MM/DD HH:MM')}
+              </S.PropertyValue>
+            </S.PropertyRow>
+          </S.InfoContent>
+        </S.Info>
+        <S.Info>
+          <S.InfoHeader>PUBLISHED</S.InfoHeader>
+          <S.InfoContent>
+            {writingInfo.publishedDetails.map(({ blogName, publishedAt, tags }) => {
+              return (
+                <Fragment key={blogName}>
+                  <S.PropertyRow>
+                    <S.PropertyName>
+                      {blogIcon[blogName]} {blogName}
+                    </S.PropertyName>
+                    <S.PropertyValue>
+                      {dateFormatter(publishedAt, 'YYYY/MM/DD HH:MM')}
+                    </S.PropertyValue>
+                  </S.PropertyRow>
+                  <S.PropertyRow>
+                    <S.PropertyName>
+                      <TagIcon width={12} height={12} />
+                      Tags
+                    </S.PropertyName>
+                    <S.PropertyValue>
+                      {tags.map((tag) => (
+                        <Tag key={tag} removable={false}>
+                          {tag}
+                        </Tag>
+                      ))}
+                    </S.PropertyValue>
+                  </S.PropertyRow>
+                  <S.Spacer />
+                </Fragment>
+              );
+            })}
+          </S.InfoContent>
+        </S.Info>
+      </S.InfoList>
+    </S.WritingPropertySection>
+  );
+};
+
+export default WritingPropertySection;
+
+const S = {
+  WritingPropertySection: styled.section`
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  `,
+  SectionHeader: styled.h1`
+    display: flex;
+    gap: 1.5rem;
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 1.5rem;
+  `,
+  InfoList: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  `,
+  Info: styled.div`
+    color: ${({ theme }) => theme.color.gray7};
+  `,
+  InfoHeader: styled.h2`
+    font-size: 1.3rem;
+    font-weight: 600;
+    line-height: 1.3rem;
+  `,
+  InfoContent: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+    padding: 1.6rem 0.9rem;
+    font-size: 1.3rem;
+    line-height: 1.3rem;
+  `,
+  PropertyRow: styled.div`
+    display: flex;
+    align-items: center;
+    height: 2.3rem;
+  `,
+  PropertyName: styled.div`
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    gap: 0.4rem;
+    width: 9.5rem;
+    color: ${({ theme }) => theme.color.gray8};
+    font-size: 1.3rem;
+    font-weight: 600;
+  `,
+  PropertyValue: styled.div`
+    display: flex;
+    gap: 0.2rem;
+  `,
+  Spacer: styled.div`
+    height: 0.8rem;
+  `,
+};

--- a/frontend/src/components/WritingPropertySection/WritingPropertySection.tsx
+++ b/frontend/src/components/WritingPropertySection/WritingPropertySection.tsx
@@ -22,14 +22,14 @@ const WritingPropertySection = ({ writingId }: Props) => {
     fetcher: () => getWritingProperties(writingId),
   });
 
-  if (!writingInfo) return <></>;
+  if (!writingInfo) return null;
 
   return (
     <S.WritingPropertySection>
-      <S.SectionHeader>Writing Info</S.SectionHeader>
+      <S.SectionTitle>Writing Info</S.SectionTitle>
       <S.InfoList>
         <S.Info>
-          <S.InfoHeader>PROPERTIES</S.InfoHeader>
+          <S.InfoTitle>PROPERTIES</S.InfoTitle>
           <S.InfoContent>
             <S.PropertyRow>
               <S.PropertyName>
@@ -43,7 +43,7 @@ const WritingPropertySection = ({ writingId }: Props) => {
           </S.InfoContent>
         </S.Info>
         <S.Info>
-          <S.InfoHeader>PUBLISHED</S.InfoHeader>
+          <S.InfoTitle>PUBLISHED</S.InfoTitle>
           <S.InfoContent>
             {writingInfo.publishedDetails.map(({ blogName, publishedAt, tags }) => {
               return (
@@ -88,7 +88,7 @@ const S = {
     flex-direction: column;
     gap: 2rem;
   `,
-  SectionHeader: styled.h1`
+  SectionTitle: styled.h1`
     display: flex;
     gap: 1.5rem;
     font-size: 1.5rem;
@@ -103,7 +103,7 @@ const S = {
   Info: styled.div`
     color: ${({ theme }) => theme.color.gray7};
   `,
-  InfoHeader: styled.h2`
+  InfoTitle: styled.h2`
     font-size: 1.3rem;
     font-weight: 600;
     line-height: 1.3rem;

--- a/frontend/src/mocks/handlers/writing.ts
+++ b/frontend/src/mocks/handlers/writing.ts
@@ -1,10 +1,15 @@
 import { rest } from 'msw';
 import { writingURL } from 'constants/apis/url';
 import { writingContentMock } from 'mocks/writingContentMock';
-import { GetCategoryIdWritingListResponse, GetWritingResponse } from 'types/apis/writings';
+import {
+  GetCategoryIdWritingListResponse,
+  GetWritingPropertiesResponse,
+  GetWritingResponse,
+} from 'types/apis/writings';
 import { getWritingTableMock } from 'mocks/writingTableMock';
 
 export const writingHandlers = [
+  // 글 조회: GET
   rest.get(`${writingURL}/:writingId`, (req, res, ctx) => {
     const writingId = Number(req.params.writingId);
 
@@ -16,6 +21,34 @@ export const writingHandlers = [
           id: writingId,
           title: '테스트 글 제목',
           content: writingContentMock,
+        }),
+      );
+    }
+    return res(ctx.delay(300), ctx.status(404));
+  }),
+
+  // 글 정보: GET
+  rest.get(`${writingURL}/:writingId/properties`, (req, res, ctx) => {
+    const writingId = Number(req.params.writingId);
+
+    if (writingId === 200) {
+      return res(
+        ctx.delay(300),
+        ctx.status(200),
+        ctx.json<GetWritingPropertiesResponse>({
+          createdAt: new Date('2023-07-11T06:55:46.922Z'),
+          publishedDetails: [
+            {
+              blogName: 'MEDIUM',
+              publishedAt: new Date('2023-07-11T06:55:46.922Z'),
+              tags: ['개발', '네트워크', '서버'],
+            },
+            {
+              blogName: 'TISTORY',
+              publishedAt: new Date('2023-06-11T06:55:46.922Z'),
+              tags: ['프로그래밍', 'CS'],
+            },
+          ],
         }),
       );
     }

--- a/frontend/src/types/apis/writings.ts
+++ b/frontend/src/types/apis/writings.ts
@@ -10,9 +10,7 @@ export type GetWritingResponse = {
 
 export type GetWritingPropertiesResponse = {
   createdAt: Date;
-  isPublished: boolean;
-  publishedAt: Date;
-  publishedTo: Blog;
+  publishedDetails: PublishedDetail[];
 };
 
 export type PublishWritingRequest = {
@@ -27,13 +25,14 @@ export type PublishWritingArgs = {
 export type PublishedDetail = {
   blogName: Blog;
   publishedAt: Date;
+  tags: string[];
 };
 
 export type Writing = {
   id: number;
   title: string;
   createdAt: Date;
-  publishedDetails: PublishedDetail[];
+  publishedDetails: Omit<PublishedDetail, 'tags'>[];
 };
 
 export type GetCategoryIdWritingListResponse = {

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,6 +1,17 @@
-export const dateFormatter = (date: Date, format: 'YYYY.MM.DD.') => {
+type dateFormate = 'YYYY.MM.DD.' | 'YYYY/MM/DD HH:MM';
+
+export const dateFormatter = (date: Date, format: dateFormate) => {
   switch (format) {
     case 'YYYY.MM.DD.':
       return new Intl.DateTimeFormat('ko-KR').format(new Date(date));
+    case 'YYYY/MM/DD HH:MM':
+      const d = new Date(date);
+      const year = d.getFullYear();
+      const month = String(d.getMonth() + 1).padStart(2, '0');
+      const day = String(d.getDate()).padStart(2, '0');
+      const hours = String(d.getHours()).padStart(2, '0');
+      const minutes = String(d.getMinutes()).padStart(2, '0');
+
+      return `${year}/${month}/${day} ${hours}:${minutes}`;
   }
 };


### PR DESCRIPTION
### 🛠️ Issue

- close #133

### ✅ Tasks
- [x] 글 정보 section 구현
- [x] API mocking
- [x] API 연결

### ⏰ Time Difference
- 3(+1)

### 📝 Note
- 글 정보 섹션을 구현했어요. 폰트 적용도 해야할 듯 하네요 기본 폰트가..
<img width="393" alt="스크린샷 2023-08-01 오전 3 05 12" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/60ba199b-d8df-491d-addf-8ede41f6f0af">

#### TODO
머지되지 않은 PR들 다 머지되면 마지막으로 사이드바 할 것
- Tab에 글 정보 섹션 추가
- 글 발행 완료 시 글 정보 섹션으로 이동
