### PR TITLE
[FE] chore: 프론트엔드 환경변수(`.env`, `cross-env`) 설정

### DIFF
--- a/.github/workflows/cicd-fe.yml
+++ b/.github/workflows/cicd-fe.yml
@@ -13,13 +13,15 @@ permissions:
 
 jobs:
   build:
-    
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: move to frontend path
         run: |
           cd ./frontend
+      - name: Create .env.development variable
+        run: touch .env.development
+          echo "BASE_URL=${{secrets.BASE_URL_DEVELOPMENT}}" >> .env.development
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -37,7 +39,7 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/dong-gle-frontend:latest
           platforms: linux/arm64
-    
+
   deploy:
     needs: build
     uses: ./.github/workflows/deploy.yml

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 yarn-error.log
+.env

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 dist/
 yarn-error.log
-.env
+.env.*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY package.json .
 RUN yarn install
 COPY ./ ./
-RUN yarn build
+RUN yarn build:dev
 
 FROM nginx
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,8 @@
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.dev.js",
-    "start": "webpack serve --config webpack.dev.js",
-    "start:mocking": "yarn start && --env MOCKING",
+    "start": "cross-env NODE_ENV=development webpack serve --config webpack.dev.js",
+    "start:mocking": "cross-env MOCKING_ENV=true yarn start",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "jest --maxWorkers=50%"
@@ -40,6 +40,7 @@
     "@types/styled-components": "5.1.26",
     "@typescript-eslint/eslint-plugin": "5.61.0",
     "@typescript-eslint/parser": "5.61.0",
+    "cross-env": "^7.0.3",
     "dotenv-webpack": "^8.0.1",
     "eslint": "8.44.0",
     "eslint-config-prettier": "8.8.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "build": "webpack --config webpack.dev.js",
+    "build:prod": "cross-env NODE_ENV=production webpack --config webpack.prod.js",
+    "build:dev": "cross-env NODE_ENV=development webpack --config webpack.dev.js",
     "start": "cross-env NODE_ENV=development webpack serve --config webpack.dev.js",
     "start:mocking": "cross-env MOCKING_ENV=true yarn start",
     "storybook": "storybook dev -p 6006",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "@types/styled-components": "5.1.26",
     "@typescript-eslint/eslint-plugin": "5.61.0",
     "@typescript-eslint/parser": "5.61.0",
+    "dotenv-webpack": "^8.0.1",
     "eslint": "8.44.0",
     "eslint-config-prettier": "8.8.0",
     "eslint-import-resolver-typescript": "3.5.5",

--- a/frontend/src/constants/apis/url.ts
+++ b/frontend/src/constants/apis/url.ts
@@ -1,2 +1,2 @@
-export const baseURL = 'http://3.38.154.137:8080';
+export const baseURL = process.env.BASE_URL;
 export const writingURL = `${baseURL}/writings`;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,11 +7,11 @@ import { Router } from 'routes/Router';
 import GlobalStyle from 'styles/GlobalStyle';
 import { theme } from 'styles/theme';
 
-// if (process.env.NODE_ENV === 'development' && process.env.MOCKING) {
-//   worker.start({
-//     onUnhandledRequest: 'bypass',
-//   });
-// }
+if (MOCKING_ENV === 'true') {
+  worker.start({
+    onUnhandledRequest: 'bypass',
+  });
+}
 
 const root = createRoot(document.getElementById('root') as HTMLElement);
 root.render(

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -1,0 +1,2 @@
+declare const PRODUCT_ENV: 'production' | 'development';
+declare const MOCKING_ENV: 'true' | 'false';

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const Dotenv = require('dotenv-webpack');
 
 module.exports = {
   mode: 'development',
@@ -43,6 +44,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: path.join(__dirname, 'public', 'index.html'),
     }),
+    new Dotenv(),
   ],
   devServer: {
     hot: true,

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const Dotenv = require('dotenv-webpack');
 
 module.exports = {
   mode: 'development',
@@ -44,7 +43,6 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: path.join(__dirname, 'public', 'index.html'),
     }),
-    new Dotenv(),
   ],
   devServer: {
     hot: true,

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -1,5 +1,7 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
+const Dotenv = require('dotenv-webpack');
+const webpack = require('webpack');
 
 module.exports = merge(common, {
   mode: 'development',
@@ -10,4 +12,11 @@ module.exports = merge(common, {
     hot: true,
     open: true,
   },
+  plugins: [
+    new Dotenv(),
+    new webpack.DefinePlugin({
+      PRODUCT_ENV: JSON.stringify(process.env.NODE_ENV),
+      MOCKING_ENV: JSON.stringify(process.env.MOCKING_ENV),
+    }),
+  ],
 });

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -13,7 +13,7 @@ module.exports = merge(common, {
     open: true,
   },
   plugins: [
-    new Dotenv(),
+    new Dotenv({ path: './.env.development' }),
     new webpack.DefinePlugin({
       PRODUCT_ENV: JSON.stringify(process.env.NODE_ENV),
       MOCKING_ENV: JSON.stringify(process.env.MOCKING_ENV),

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5035,7 +5035,14 @@ cosmiconfig@^8.1.3:
     parse-json "^5.0.0"
     path-type "^4.0.0"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5487,15 +5487,34 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dotenv-defaults@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz#6b3ec2e4319aafb70940abda72d3856770ee77ac"
+  integrity sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==
+  dependencies:
+    dotenv "^8.2.0"
+
 dotenv-expand@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
   integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
 
+dotenv-webpack@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz#6656550460a8076fab20e5ac2eac867e72478645"
+  integrity sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==
+  dependencies:
+    dotenv-defaults "^2.0.2"
+
 dotenv@^16.0.0:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
+dotenv@^8.2.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
 duplexify@^3.5.0, duplexify@^3.6.0:
   version "3.7.1"


### PR DESCRIPTION
### 🛠️ Issue

- close #146 

### ✅ Tasks
- 환경변수 관련 라이브러리 `cross-env`, `dotenv-webpack` 설치
- 환경변수 github secrets에 추가 (`BASE_URL_DEVELOPMENT`, `BASE_URL_PRODUCTION`)
  - <img width="1068" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/33623078/640e0e9d-86e2-4fd9-a9b8-48b6e5d87fb4">
 
- 프론트엔드 cicd yml 파일(github actions)에서 환경변수 파일 만들어서 주입
- 프론트엔드 Dockerfile 빌드 명령어 변경
- 로컬에 `.env.development`, `.env.production` 추가 (공유 예정)

### ⏰ Time Difference
- (6) + 3

### 📝 Note
현재 cicd yml과 Dockerfile은 dev 서버 기준으로 작성되어 있습니다.
추후 production 환경을 구성할 때,  cicd yml과 Dockerfile을 따로 만들어야합니다.
