### PR TITLE
[BE] fix: 카테고리 오류 수정 및 개발 환경 수정

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/service/CategoryService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/CategoryService.java
@@ -129,13 +129,19 @@ public class CategoryService {
 
     private void transferToBasicCategory(final Long memberId, final Category findCategory) {
         final Category basicCategory = findBasicCategoryByMemberId(memberId);
-        final List<Writing> findWritings = writingRepository.findAllByCategoryId(findCategory.getId());
-        if (!findWritings.isEmpty()) {
+        if (haveWritingsCategory(findCategory)) {
+            final List<Writing> findWritings = writingRepository.findAllByCategoryId(findCategory.getId());
             final Writing firstWritingInCategory = findFirstWriting(findWritings);
-            final Writing lastWriting = findLastWritingInCategory(findCategory);
-            lastWriting.changeNextWriting(firstWritingInCategory);
+            if (haveWritingsCategory(basicCategory)) {
+                final Writing lastWritingInBasicCategory = findLastWritingInCategory(basicCategory);
+                lastWritingInBasicCategory.changeNextWriting(firstWritingInCategory);
+            }
             findWritings.forEach(writing -> writing.changeCategory(basicCategory));
         }
+    }
+
+    private boolean haveWritingsCategory(final Category category) {
+        return !writingRepository.findAllByCategoryId(category.getId()).isEmpty();
     }
 
     private void deleteCategory(final Category findCategory) {

--- a/backend/src/main/java/org/donggle/backend/application/service/CategoryService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/CategoryService.java
@@ -129,11 +129,13 @@ public class CategoryService {
 
     private void transferToBasicCategory(final Long memberId, final Category findCategory) {
         final Category basicCategory = findBasicCategoryByMemberId(memberId);
-        final List<Writing> writings = writingRepository.findAllByCategoryId(findCategory.getId());
-        final Writing firstWritingInCategory = findFirstWriting(writings);
-        final Writing lastWriting = findLastWritingInCategory(findCategory);
-        lastWriting.changeNextWriting(firstWritingInCategory);
-        writings.forEach(writing -> writing.changeCategory(basicCategory));
+        final List<Writing> findWritings = writingRepository.findAllByCategoryId(findCategory.getId());
+        if (!findWritings.isEmpty()) {
+            final Writing firstWritingInCategory = findFirstWriting(findWritings);
+            final Writing lastWriting = findLastWritingInCategory(findCategory);
+            lastWriting.changeNextWriting(firstWritingInCategory);
+            findWritings.forEach(writing -> writing.changeCategory(basicCategory));
+        }
     }
 
     private void deleteCategory(final Category findCategory) {

--- a/backend/src/main/java/org/donggle/backend/application/service/CategoryService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/CategoryService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,6 +78,9 @@ public class CategoryService {
         //TODO: member checking
         final Category findCategory = findCategory(categoryId);
         final List<Writing> findWritings = writingRepository.findAllByCategoryId(findCategory.getId());
+        if (findWritings.isEmpty()) {
+            return CategoryWritingsResponse.of(findCategory, Collections.emptyList());
+        }
         final Writing firstWriting = findFirstWriting(findWritings);
         final List<Writing> sortedWriting = sortWriting(findWritings, firstWriting);
         final List<WritingSimpleResponse> writingSimpleResponses = sortedWriting.stream()

--- a/backend/src/main/java/org/donggle/backend/application/service/WritingService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/WritingService.java
@@ -40,6 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -158,6 +159,9 @@ public class WritingService {
         //TODO: member checking
         final Category findCategory = findCategory(categoryId);
         final List<Writing> findWritings = writingRepository.findAllByCategoryId(findCategory.getId());
+        if (findWritings.isEmpty()) {
+            return WritingListWithCategoryResponse.of(findCategory, Collections.emptyList());
+        }
         final Writing firstWriting = findFirstWriting(findWritings);
         final List<Writing> sortedWriting = sortWriting(findWritings, firstWriting);
         final List<WritingDetailResponse> writingDetailResponses = sortedWriting.stream()

--- a/backend/src/main/java/org/donggle/backend/domain/writing/content/RawText.java
+++ b/backend/src/main/java/org/donggle/backend/domain/writing/content/RawText.java
@@ -2,7 +2,6 @@ package org.donggle.backend.domain.writing.content;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.Lob;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +12,7 @@ import java.util.Objects;
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RawText {
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "CLOB")
     private String rawText;
 
     private RawText(final String rawText) {

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -5,7 +5,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
@@ -134,7 +134,8 @@ class CategoryServiceTest {
                 () -> assertThat(categories).hasSize(1),
                 () -> assertThat(categories.get(0).getCategoryName()).isEqualTo(new CategoryName("기본")),
                 () -> assertThat(categories.get(0).getNextCategory()).isNull(),
-                () -> assertThat(writing.getCategory()).isEqualTo(categories.get(0))
+                () -> assertThat(writing.getCategory()).isEqualTo(categories.get(0)),
+                () -> assertThat(writing.getNextWriting()).isNull()
         );
     }
 

--- a/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
@@ -156,6 +156,23 @@ class CategoryServiceTest {
     }
 
     @Test
+    @DisplayName("비어있는 카테고리 글 목록 조회 테스트")
+    void findAllWritingsByIdWithEmptyCategory() {
+        //given
+        final Long secondId = categoryService.addCategory(1L, new CategoryAddRequest("두 번째 카테고리"));
+
+        //when
+        final CategoryWritingsResponse response = categoryService.findAllWritings(1L, secondId);
+
+        //then
+        assertAll(
+                () -> assertThat(response.writings()).hasSize(0),
+                () -> assertThat(response.writings()).isEmpty(),
+                () -> assertThat(response.categoryName()).isEqualTo("두 번째 카테고리")
+        );
+    }
+
+    @Test
     @DisplayName("카테고리 순서 수정 테스트")
     void modifyCategoryOrder() {
         //given

--- a/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
@@ -139,6 +139,25 @@ class CategoryServiceTest {
     }
 
     @Test
+    @DisplayName("비어있는 카테고리 삭제 테스트")
+    void removeCategoryWithEmptyCategory() {
+        //given
+        final Long secondId = categoryService.addCategory(1L, new CategoryAddRequest("두 번째 카테고리"));
+
+        //when
+        categoryService.removeCategory(1L, secondId);
+        final List<Category> categories = categoryRepository.findAllByMemberId(1L);
+        categoryRepository.flush();
+
+        //then
+        assertAll(
+                () -> assertThat(categories).hasSize(1),
+                () -> assertThat(categories.get(0).getCategoryName()).isEqualTo(new CategoryName("기본")),
+                () -> assertThat(categories.get(0).getNextCategory()).isNull()
+        );
+    }
+
+    @Test
     @DisplayName("카테고리 글 목록 조회 테스트")
     void findAllWritingsById() {
         //given


### PR DESCRIPTION
### 🛠️ Issue

- close #179 

### ✅ Tasks
-  카테고리 생성 후 목록 조회 시, 글 목록이 비어있을 때 빈 배열을 전송하도록 수정
-  카테고리 삭제 수정
    - 삭제된 카테고리 내의 글이 비어있을 때, 기본 카테고리로 글을 이동시키는 로직을 적용하지 않도록
    - 카테고리 삭제시 기본 카테고리가 비어있을 때 순환 참조가 일어난다.
    - 글이 있는 카테고리를 삭제시, 기본 카테고리에서 순환 참조가 일어난다.
-  production 환경의 JPA 테이블 생성 전략 수정
-  RawText에 columnDefinition 조건 추가

### ⏰ Time Difference
- 2 -> 1

