### PR TITLE
[FE] chore: frontend 브랜치별 docker 이미지 분리

### DIFF
--- a/.github/workflows/cicd-fe-prod.yml
+++ b/.github/workflows/cicd-fe-prod.yml
@@ -39,7 +39,7 @@ jobs:
           context: ./frontend
           file: ./frontend/Dockerfile-prod
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/dong-gle-frontend:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/dong-gle-frontend-prod:latest
           platforms: linux/arm64
 
   deploy:

--- a/.github/workflows/cicd-fe.yml
+++ b/.github/workflows/cicd-fe.yml
@@ -39,7 +39,7 @@ jobs:
           context: ./frontend
           file: ./frontend/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/dong-gle-frontend:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/dong-gle-frontend-dev:latest
           platforms: linux/arm64
 
   deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   frontend:
-    image: ${DOCKER_USERNAME}/dong-gle-frontend
+    image: ${DOCKER_USERNAME}/dong-gle-frontend-${PROFILE}
     expose:
       - 3000
 


### PR DESCRIPTION
### 🛠️ Issue

- close #199 

### ✅ Tasks
- [x] frontend prod, dev 이미지 분리
- [x] github actions에서 main, develop 브랜치에 따라 이미지 빌드 분리
- [x] docker compose에서 분리된 이미지 따로 부르도록 설정

### ⏰ Time Difference
- 0