### PR TITLE
[All] chore: 시멘틱 버저닝

### DIFF
--- a/.github/draft-release.yml
+++ b/.github/draft-release.yml
@@ -1,0 +1,17 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## 변경사항
+  $CHANGES

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -1,0 +1,64 @@
+name: semantic-versioning
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  semantic-versioning:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.base_ref == 'main'
+    steps:
+      - name: semantic-versioning
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: draft-release.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  package-version-update:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.base_ref == 'main'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Github 회원 정보 설정
+        env:
+          MY_EMAIL: 2023donggle@gmail.com
+          MY_NAME: Dong-gle
+        run: |
+          git config --global user.email $MY_EMAIL
+          git config --global user.name $MY_NAME
+
+      - name: Node.js 설치
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: PR Label 확인
+        id: pr-labels
+        uses: joerick/pr-labels-action@v1.0.9
+
+      - name: 메이저 버전 업데이트
+        if: |
+          contains(steps.pr-labels.outputs.labels, ' major ')
+        run: |
+          yarn version --major
+        working-directory: ./frontend
+
+      - name: 마이너 버전 업데이트
+        if: |
+          contains(steps.pr-labels.outputs.labels, ' minor ')
+        run: |
+          yarn version --minor
+        working-directory: ./frontend
+
+      - name: 패치 버전 업데이트
+        if: |
+          contains(steps.pr-labels.outputs.labels, ' patch ')
+        run: |
+          yarn version --patch
+        working-directory: ./frontend
+
+      - name: main 브랜치 Push
+        uses: ad-m/github-push-action@master
+        with:
+          branch: 'main'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "main": "index.tsx",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
### 🛠️ Issue

- close #238

### ✅ Tasks
- [x] main으로 머지 될 때 자동으로 tag와 release note의 버전을 업데이트 하여 작성
- [x] frontend/package.json의 version도 같이 업데이트

### ⏰ Time Difference
- 4 -> 6

### 📝 Note
**main으로 pr날릴 때** label(`major`, `minor`, `patch`)에 따라서 tag의 버전이 업데이트 됩니다. 

또한 그 태그에 해당하는 release note가 초안으로 생성되며 작성완료는 직접 해줘야 합니다.

<img width="580" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/75ab6972-cbc1-4af4-bc05-86fd4cf5e5dd">

frontend/package.json 에 있는 version 역시 같이 업데이트 되며 이 변경사항은 main으로 바로 push 됩니다.
이 커밋을 통해서 어디까지가 어떤 버전인지 확인 가능합니다.

그리고 이 PR이 main으로 merge되야 다음 main에 머지될 때부터 반영될 것 같은데 어떻게 할까요?