### PR TITLE
[BE] feat: 티스토리 블로그 이름 가져오는 기능 구현

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/service/PublishService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/PublishService.java
@@ -15,7 +15,7 @@ import org.donggle.backend.application.service.vendor.medium.dto.request.MediumR
 import org.donggle.backend.application.service.vendor.medium.dto.response.MediumPublishResponse;
 import org.donggle.backend.application.service.vendor.tistory.TistoryApiService;
 import org.donggle.backend.application.service.vendor.tistory.dto.request.TistoryPublishRequest;
-import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryPublishWritingResponse;
+import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryGetWritingResponseWrapper;
 import org.donggle.backend.domain.blog.Blog;
 import org.donggle.backend.domain.blog.BlogType;
 import org.donggle.backend.domain.blog.BlogWriting;
@@ -84,7 +84,7 @@ public class PublishService {
 
     private BlogWriting createBlogWritingAfterTistoryPublish(final PublishRequest publishRequest, final Member member, final Blog blog, final Writing writing, final String content) {
         final TistoryPublishRequest request = buildTistoryRequest(member, publishRequest, writing, content);
-        final TistoryPublishWritingResponse response = tistoryApiService.publishContent(request);
+        final TistoryGetWritingResponseWrapper response = tistoryApiService.publishContent(request);
         return new BlogWriting(blog, writing, response.getDateTime(), response.getTags());
     }
 
@@ -93,7 +93,7 @@ public class PublishService {
         final MemberCredentials memberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(member).orElseThrow();
         //TODO TistoryBlogName 못찾은 예외 발생시키기
         final String tistoryToken = memberCredentials.getTistoryToken();
-        final String tistoryBlogName = memberCredentials.getTistoryBlogName();
+        final String tistoryBlogName = tistoryApiService.getDefaultTistoryBlogName(tistoryToken);
         return TistoryPublishRequest.builder()
                 .access_token(tistoryToken)
                 .blogName(tistoryBlogName)

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/TistoryApiService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/TistoryApiService.java
@@ -1,14 +1,16 @@
 package org.donggle.backend.application.service.vendor.tistory;
 
 import org.donggle.backend.application.service.vendor.exception.VendorApiInternalServerError;
+import org.donggle.backend.application.service.vendor.tistory.dto.TistoryBlogInfoResponseWrapper;
+import org.donggle.backend.application.service.vendor.tistory.dto.TistoryBlogResponse;
 import org.donggle.backend.application.service.vendor.tistory.dto.request.TistoryPublishPropertyRequest;
 import org.donggle.backend.application.service.vendor.tistory.dto.request.TistoryPublishRequest;
-import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryPublishStatusResponse;
-import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryPublishWritingResponse;
-import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryResponse;
+import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryGetWritingResponseWrapper;
+import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryPublishWritingResponseWrapper;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.donggle.backend.application.service.vendor.exception.VendorApiException.handle4xxException;
 
@@ -22,8 +24,8 @@ public class TistoryApiService {
         this.webClient = WebClient.create(TISTORY_URL);
     }
 
-    public TistoryPublishWritingResponse publishContent(final TistoryPublishRequest request) {
-        final TistoryPublishStatusResponse response = webClient.post()
+    public TistoryGetWritingResponseWrapper publishContent(final TistoryPublishRequest request) {
+        final TistoryPublishWritingResponseWrapper response = webClient.post()
                 .uri("/post/write?")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
@@ -31,28 +33,39 @@ public class TistoryApiService {
                 .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> handle4xxException(clientResponse.statusCode().value(), PLATFORM_NAME))
                 .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> clientResponse.bodyToMono(String.class)
                         .map(e -> new VendorApiInternalServerError(PLATFORM_NAME)))
-                .bodyToMono(TistoryPublishStatusResponse.class)
+                .bodyToMono(TistoryPublishWritingResponseWrapper.class)
                 .block();
-        validateResponse(response);
-
         return findPublishProperty(makeTistoryPublishPropertyRequest(request, response));
     }
 
-    private TistoryPublishPropertyRequest makeTistoryPublishPropertyRequest(final TistoryPublishRequest request, final TistoryPublishStatusResponse response) {
+    private TistoryPublishPropertyRequest makeTistoryPublishPropertyRequest(final TistoryPublishRequest request, final TistoryPublishWritingResponseWrapper response) {
         return TistoryPublishPropertyRequest.builder()
                 .access_token(request.access_token())
                 .postId(response.tistory().postId())
-                .blogName(request.blogName())
+                .blogName(getDefaultTistoryBlogName(request.access_token()))
                 .build();
     }
 
-    private void validateResponse(final TistoryResponse response) {
-        if (response.getStatus() != OK) {
-            throw new IllegalArgumentException("블로그로 발행이 올바르게 되지 않았습니다.");
-        }
+    public String getDefaultTistoryBlogName(final String access_token) {
+        final String blogInfoUri = UriComponentsBuilder.fromUriString(TISTORY_URL)
+                .path("/blog/info")
+                .queryParam("access_token", access_token)
+                .queryParam("output", "json")
+                .build()
+                .toUriString();
+        final TistoryBlogInfoResponseWrapper BlogInfo = webClient.get()
+                .uri(blogInfoUri)
+                .retrieve()
+                .bodyToMono(TistoryBlogInfoResponseWrapper.class)
+                .block();
+        return BlogInfo.tistory().item().blogs().stream()
+                .filter(blog -> blog.defaultValue().equals("Y"))
+                .map(TistoryBlogResponse::name)
+                .findFirst()
+                .orElseThrow();
     }
 
-    public TistoryPublishWritingResponse findPublishProperty(final TistoryPublishPropertyRequest request) {
+    public TistoryGetWritingResponseWrapper findPublishProperty(final TistoryPublishPropertyRequest request) {
         return webClient.get()
                 .uri("/post/read?" +
                         "access_token=" + request.access_token() +
@@ -63,7 +76,7 @@ public class TistoryApiService {
                 .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> handle4xxException(clientResponse.statusCode().value(), PLATFORM_NAME))
                 .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> clientResponse.bodyToMono(String.class)
                         .map(e -> new VendorApiInternalServerError(PLATFORM_NAME)))
-                .bodyToMono(TistoryPublishWritingResponse.class)
+                .bodyToMono(TistoryGetWritingResponseWrapper.class)
                 .block();
     }
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/TistoryApiService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/TistoryApiService.java
@@ -17,7 +17,7 @@ import static org.donggle.backend.application.service.vendor.exception.VendorApi
 public class TistoryApiService {
     public static final String PLATFORM_NAME = "Tistory";
     private static final String TISTORY_URL = "https://www.tistory.com/apis";
-    private static final int OK = 200;
+
     private final WebClient webClient;
 
     public TistoryApiService() {
@@ -53,12 +53,12 @@ public class TistoryApiService {
                 .queryParam("output", "json")
                 .build()
                 .toUriString();
-        final TistoryBlogInfoResponseWrapper BlogInfo = webClient.get()
+        final TistoryBlogInfoResponseWrapper blogInfo = webClient.get()
                 .uri(blogInfoUri)
                 .retrieve()
                 .bodyToMono(TistoryBlogInfoResponseWrapper.class)
                 .block();
-        return BlogInfo.tistory().item().blogs().stream()
+        return blogInfo.tistory().item().blogs().stream()
                 .filter(blog -> blog.defaultValue().equals("Y"))
                 .map(TistoryBlogResponse::name)
                 .findFirst()
@@ -66,12 +66,15 @@ public class TistoryApiService {
     }
 
     public TistoryGetWritingResponseWrapper findPublishProperty(final TistoryPublishPropertyRequest request) {
+        final String publishPropertyUri = UriComponentsBuilder.fromUriString("/post/read")
+                .queryParam("access_token", request.access_token())
+                .queryParam("blogName", request.blogName())
+                .queryParam("postId", request.postId())
+                .queryParam("output", "json")
+                .build()
+                .toUriString();
         return webClient.get()
-                .uri("/post/read?" +
-                        "access_token=" + request.access_token() +
-                        "&blogName=" + request.blogName() +
-                        "&postId=" + request.postId() +
-                        "&output=json")
+                .uri(publishPropertyUri)
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> handle4xxException(clientResponse.statusCode().value(), PLATFORM_NAME))
                 .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> clientResponse.bodyToMono(String.class)

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/TistoryBlogInfoResponse.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/TistoryBlogInfoResponse.java
@@ -1,0 +1,10 @@
+package org.donggle.backend.application.service.vendor.tistory.dto;
+
+import java.util.List;
+
+public record TistoryBlogInfoResponse(
+        String id,
+        Long userId,
+        List<TistoryBlogResponse> blogs
+) {
+}

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/TistoryBlogInfoResponseWrapper.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/TistoryBlogInfoResponseWrapper.java
@@ -1,0 +1,8 @@
+package org.donggle.backend.application.service.vendor.tistory.dto;
+
+import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryItemResponse;
+
+public record TistoryBlogInfoResponseWrapper(
+        TistoryItemResponse<TistoryBlogInfoResponse> tistory
+) {
+}

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/TistoryBlogResponse.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/TistoryBlogResponse.java
@@ -1,0 +1,21 @@
+package org.donggle.backend.application.service.vendor.tistory.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TistoryBlogResponse(
+        String name,
+        String url,
+        String secondaryUrl,
+        String nickname,
+        String title,
+        String description,
+        @JsonProperty("default")
+        String defaultValue,
+        String blogIconUrl,
+        String faviconUrl,
+        String profileThumbnailImageUrl,
+        String profileImageUrl,
+        String role,
+        TistoryBlogStatsResponse stats
+) {
+}

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/TistoryBlogStatsResponse.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/TistoryBlogStatsResponse.java
@@ -1,0 +1,10 @@
+package org.donggle.backend.application.service.vendor.tistory.dto;
+
+public record TistoryBlogStatsResponse(
+        int post,
+        int comment,
+        int trackback,
+        int guestbook,
+        int invitation
+) {
+}

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/request/TistoryPublishRequest.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/request/TistoryPublishRequest.java
@@ -7,8 +7,8 @@ import java.util.List;
 @Builder
 public record TistoryPublishRequest(
         String access_token,
-        String output,
         String blogName,
+        String output,
         String title,
         String content,
         int visibility,

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/request/TistoryPublishWritingDataRequest.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/request/TistoryPublishWritingDataRequest.java
@@ -1,9 +1,0 @@
-package org.donggle.backend.application.service.vendor.tistory.dto.request;
-
-import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryPublishWritingDataResponse;
-
-public record TistoryPublishWritingDataRequest(
-        int status,
-        TistoryPublishWritingDataResponse item
-) {
-}

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryGetWritingResponse.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryGetWritingResponse.java
@@ -6,7 +6,7 @@ import org.donggle.backend.application.service.vendor.tistory.TistoryTagsDeseria
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-public record TistoryPublishWritingDataResponse(
+public record TistoryGetWritingResponse(
         String url,
         String secondaryUrl,
         String id,

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryGetWritingResponseWrapper.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryGetWritingResponseWrapper.java
@@ -1,0 +1,14 @@
+package org.donggle.backend.application.service.vendor.tistory.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TistoryGetWritingResponseWrapper(TistoryItemResponse<TistoryGetWritingResponse> tistory) {
+    public LocalDateTime getDateTime() {
+        return tistory.item().getDateTime();
+    }
+
+    public List<String> getTags() {
+        return tistory.item().tags().tags();
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryItemResponse.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryItemResponse.java
@@ -1,8 +1,7 @@
 package org.donggle.backend.application.service.vendor.tistory.dto.response;
 
-public record TistoryPublishStatusDataResponse(
+public record TistoryItemResponse<T>(
         int status,
-        Long postId,
-        String url
+        T item
 ) {
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryPublishStatusResponse.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryPublishStatusResponse.java
@@ -1,8 +1,0 @@
-package org.donggle.backend.application.service.vendor.tistory.dto.response;
-
-public record TistoryPublishStatusResponse(TistoryPublishStatusDataResponse tistory) implements TistoryResponse {
-    @Override
-    public int getStatus() {
-        return tistory.status();
-    }
-}

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryPublishWritingResponse.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryPublishWritingResponse.java
@@ -1,21 +1,8 @@
 package org.donggle.backend.application.service.vendor.tistory.dto.response;
 
-import org.donggle.backend.application.service.vendor.tistory.dto.request.TistoryPublishWritingDataRequest;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-public record TistoryPublishWritingResponse(TistoryPublishWritingDataRequest tistory) implements TistoryResponse {
-    @Override
-    public int getStatus() {
-        return tistory.status();
-    }
-
-    public LocalDateTime getDateTime() {
-        return tistory.item().getDateTime();
-    }
-
-    public List<String> getTags() {
-        return tistory.item().tags().tags();
-    }
+public record TistoryPublishWritingResponse(
+        int status,
+        Long postId,
+        String url
+) {
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryPublishWritingResponseWrapper.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryPublishWritingResponseWrapper.java
@@ -1,0 +1,4 @@
+package org.donggle.backend.application.service.vendor.tistory.dto.response;
+
+public record TistoryPublishWritingResponseWrapper(TistoryPublishWritingResponse tistory) {
+}

--- a/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryResponse.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/vendor/tistory/dto/response/TistoryResponse.java
@@ -1,5 +1,0 @@
-package org.donggle.backend.application.service.vendor.tistory.dto.response;
-
-public interface TistoryResponse {
-    int getStatus();
-}

--- a/backend/src/test/java/org/donggle/backend/application/service/tistory/TistoryApiServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/tistory/TistoryApiServiceTest.java
@@ -1,10 +1,9 @@
 package org.donggle.backend.application.service.tistory;
 
-import org.assertj.core.api.Assertions;
 import org.donggle.backend.application.service.vendor.tistory.TistoryApiService;
 import org.donggle.backend.application.service.vendor.tistory.dto.request.TistoryPublishPropertyRequest;
 import org.donggle.backend.application.service.vendor.tistory.dto.request.TistoryPublishRequest;
-import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryPublishWritingResponse;
+import org.donggle.backend.application.service.vendor.tistory.dto.response.TistoryGetWritingResponseWrapper;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,7 @@ class TistoryApiServiceTest {
                 .build();
 
         //when
-        final TistoryPublishWritingResponse result = tistoryApiService.publishContent(request);
+        final TistoryGetWritingResponseWrapper result = tistoryApiService.publishContent(request);
 
         //then
         assertThat(result.tistory().status()).isEqualTo(200);
@@ -66,9 +65,23 @@ class TistoryApiServiceTest {
                 .build();
 
         //when
-        final TistoryPublishWritingResponse publishProperty = tistoryApiService.findPublishProperty(tistoryPublishPropertyRequest);
+        final TistoryGetWritingResponseWrapper publishProperty = tistoryApiService.findPublishProperty(tistoryPublishPropertyRequest);
 
         //then
         assertThat(publishProperty.tistory().status()).isEqualTo(200);
+    }
+
+    @Test
+    @Disabled
+    @DisplayName("블로그 정보 조회 테스트")
+    void findBlogInfo() {
+        //given
+        final TistoryApiService tistoryApiService = new TistoryApiService();
+
+        //when
+        final String blogName = tistoryApiService.getDefaultTistoryBlogName("token");
+
+        //then
+        assertThat(blogName).isEqualTo("blogName");
     }
 }


### PR DESCRIPTION
### 🛠️ Issue

- close #265 

### ✅ Tasks
- Tistory API Response DTO 정리
- 글 발행시 Tistory 블로그 이름을 조회하여 찾은뒤 발행할 수 있도록 변경
- 이름 찾는 테스트 추가(Disabled)

### ⏰ Time Difference
- 0

### 📝 Note
- 티스토리 블로그 발행을 위해서는 블로그 이름이 필요합니다.({name}.tistory.com)의 이름이 필요합니다.
- 전에는 티스토리 블로그 이름을 DB에 직접 주입하여 글을 발행하였습니다.
- 이번 기능으로 access token을 통해 블로그 이름을 찾아올 수 있습니다.
- Member Credential쪽 기능이 완성되면 블로그 이름을 한 번 찾고 DB에 영속화하는 형식으로 구현해나갈 수 있을 것 같습니다.