### PR TITLE
[BE] feat: 글 삭제 및 휴지통 API 구현

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -31,9 +31,9 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
             "w.status = 'TRASHED'", nativeQuery = true)
     List<Writing> findAllByMemberIdAndStatusIsTrashed(@Param("memberId") final Long memberId);
 
-    @Query(value = "select * from Writing as w" +
-            " where w.member_id = :memberId and " +
+    @Query(value = "select * from Writing as w " +
+            "where w.member_id = :memberId and " +
             "w.id = :writingId and " +
             "w.status != 'DELETED'", nativeQuery = true)
-    Optional<Writing> findByMemberIdAndIdAndStatusIsNotDeleted(@Param("memberId") final Long memberId, @Param("writingId") final Long writingId);
+    Optional<Writing> findByMemberIdAndWritingIdAndStatusIsNotDeleted(@Param("memberId") final Long memberId, @Param("writingId") final Long writingId);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -23,4 +23,17 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
     @Query("select w from Writing w " +
             "where w.nextWriting.id = :writingId")
     Optional<Writing> findPreWritingByWritingId(@Param("writingId") final Long writingId);
+
+    Optional<Writing> findByMemberIdAndId(final Long memberId, final Long writingId);
+
+    @Query(value = "select * from Writing as w " +
+            "where w.member_id = :memberId and " +
+            "w.status = 'TRASHED'", nativeQuery = true)
+    List<Writing> findAllByMemberIdAndStatusIsTrashed(@Param("memberId") final Long memberId);
+
+    @Query(value = "select * from Writing as w" +
+            " where w.member_id = :memberId and " +
+            "w.id = :writingId and " +
+            "w.status != 'DELETED'", nativeQuery = true)
+    Optional<Writing> findByMemberIdAndIdAndStatusIsNotDeleted(@Param("memberId") final Long memberId, @Param("writingId") final Long writingId);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -34,6 +34,12 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
     @Query(value = "select * from Writing as w " +
             "where w.member_id = :memberId and " +
             "w.id = :writingId and " +
+            "w.status = 'TRASHED'", nativeQuery = true)
+    Optional<Writing> findByMemberIdAndWritingIdAndStatusIsTrashed(final Long memberId, final Long writingId);
+
+    @Query(value = "select * from Writing as w " +
+            "where w.member_id = :memberId and " +
+            "w.id = :writingId and " +
             "w.status != 'DELETED'", nativeQuery = true)
     Optional<Writing> findByMemberIdAndWritingIdAndStatusIsNotDeleted(@Param("memberId") final Long memberId, @Param("writingId") final Long writingId);
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/TrashService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/TrashService.java
@@ -1,6 +1,5 @@
 package org.donggle.backend.application.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.donggle.backend.application.repository.WritingRepository;
 import org.donggle.backend.domain.writing.Writing;
@@ -8,6 +7,7 @@ import org.donggle.backend.exception.notfound.DeleteWritingNotFoundException;
 import org.donggle.backend.exception.notfound.RestoreWritingNotFoundException;
 import org.donggle.backend.ui.response.TrashResponse;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -17,6 +17,7 @@ import java.util.List;
 public class TrashService {
     private final WritingRepository writingRepository;
 
+    @Transactional(readOnly = true)
     public TrashResponse findTrashedWritingList(final Long memberId) {
         final List<Writing> trashedWritings = writingRepository.findAllByMemberIdAndStatusIsTrashed(memberId);
         return TrashResponse.from(trashedWritings);

--- a/backend/src/main/java/org/donggle/backend/application/service/TrashService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/TrashService.java
@@ -36,10 +36,11 @@ public class TrashService {
 
     public void deleteWritings(final Long memberId, final List<Long> writingIds) {
         writingIds.stream()
-                .map(writingId -> writingRepository.findByMemberIdAndIdAndStatusIsNotDeleted(memberId, writingId)
+                .map(writingId -> writingRepository.findByMemberIdAndWritingIdAndStatusIsNotDeleted(memberId, writingId)
                         .orElseThrow(() -> new DeleteWritingNotFoundException(writingId)))
                 .forEach(writing -> {
                     final Writing nextWriting = writing.getNextWriting();
+                    writing.changeNextWritingNull();
                     writingRepository.delete(writing);
                     writingRepository.findPreWritingByWritingId(writing.getId())
                             .ifPresent(preWriting -> preWriting.changeNextWriting(nextWriting));
@@ -48,7 +49,7 @@ public class TrashService {
 
     public void restoreWritings(final Long memberId, final List<Long> writingIds) {
         writingIds.stream()
-                .map(writingId -> writingRepository.findByMemberIdAndIdAndStatusIsNotDeleted(memberId, writingId)
+                .map(writingId -> writingRepository.findByMemberIdAndWritingIdAndStatusIsNotDeleted(memberId, writingId)
                         .orElseThrow(() -> new RestoreWritingNotFoundException(writingId)))
                 .forEach(writing -> {
                             writingRepository.findLastWritingByCategoryId(writing.getCategory().getId())

--- a/backend/src/main/java/org/donggle/backend/application/service/TrashService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/TrashService.java
@@ -50,7 +50,7 @@ public class TrashService {
 
     public void restoreWritings(final Long memberId, final List<Long> writingIds) {
         writingIds.stream()
-                .map(writingId -> writingRepository.findByMemberIdAndWritingIdAndStatusIsNotDeleted(memberId, writingId)
+                .map(writingId -> writingRepository.findByMemberIdAndWritingIdAndStatusIsTrashed(memberId, writingId)
                         .orElseThrow(() -> new RestoreWritingNotFoundException(writingId)))
                 .forEach(writing -> {
                             writingRepository.findLastWritingByCategoryId(writing.getCategory().getId())

--- a/backend/src/main/java/org/donggle/backend/application/service/TrashService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/TrashService.java
@@ -1,0 +1,67 @@
+package org.donggle.backend.application.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.donggle.backend.application.repository.WritingRepository;
+import org.donggle.backend.domain.writing.Writing;
+import org.donggle.backend.ui.response.TrashResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TrashService {
+    private final WritingRepository writingRepository;
+
+    public TrashResponse findTrashedWritingList(final Long memberId) {
+        final List<Writing> trashedWritings = writingRepository.findAllByMemberIdAndStatusIsTrashed(memberId);
+        return TrashResponse.from(trashedWritings);
+    }
+
+    public void trashWritings(final Long memberId, final List<Long> writingIds) {
+        checkEmptyWritings(writingIds);
+        writingIds.stream()
+                .map(writingId -> writingRepository.findByMemberIdAndId(memberId, writingId)
+                        .orElseThrow(() -> new IllegalArgumentException("삭제할 수 없는 글이 포함되어 있습니다.")))
+                .forEach(writing -> {
+                    final Writing nextWriting = writing.getNextWriting();
+                    writing.moveToTrash();
+                    writingRepository.findPreWritingByWritingId(writing.getId())
+                            .ifPresent(preWriting -> preWriting.changeNextWriting(nextWriting));
+                });
+    }
+
+    public void deleteWritings(final Long memberId, final List<Long> writingIds) {
+        checkEmptyWritings(writingIds);
+        writingIds.stream()
+                .map(writingId -> writingRepository.findByMemberIdAndIdAndStatusIsNotDeleted(memberId, writingId)
+                        .orElseThrow(() -> new IllegalArgumentException("삭제할 수 없는 글이 포함되어 있습니다.")))
+                .forEach(writing -> {
+                    final Writing nextWriting = writing.getNextWriting();
+                    writingRepository.delete(writing);
+                    writingRepository.findPreWritingByWritingId(writing.getId())
+                            .ifPresent(preWriting -> preWriting.changeNextWriting(nextWriting));
+                });
+    }
+
+    public void restoreWritings(final Long memberId, final List<Long> writingIds) {
+        checkEmptyWritings(writingIds);
+        writingIds.stream()
+                .map(writingId -> writingRepository.findByMemberIdAndIdAndStatusIsNotDeleted(memberId, writingId)
+                        .orElseThrow(() -> new IllegalArgumentException("복원할 수 없는 글이 포함되어 있습니다.")))
+                .forEach(writing -> {
+                            writingRepository.findLastWritingByCategoryId(writing.getCategory().getId())
+                                    .ifPresent(lastWriting -> lastWriting.changeNextWriting(writing));
+                            writing.restore();
+                        }
+                );
+    }
+
+    private static void checkEmptyWritings(final List<Long> writingIds) {
+        if (writingIds.isEmpty()) {
+            throw new IllegalArgumentException("삭제할 글이 없습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/application/service/request/DeleteWritingsRequest.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/request/DeleteWritingsRequest.java
@@ -1,0 +1,9 @@
+package org.donggle.backend.application.service.request;
+
+import java.util.List;
+
+public record DeleteWritingsRequest(
+        List<Long> writingIds,
+        boolean isPermanentDelete
+) {
+}

--- a/backend/src/main/java/org/donggle/backend/application/service/request/RestoreWritingsRequest.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/request/RestoreWritingsRequest.java
@@ -1,0 +1,8 @@
+package org.donggle.backend.application.service.request;
+
+import java.util.List;
+
+public record RestoreWritingsRequest(
+        List<Long> writingIds
+) {
+}

--- a/backend/src/main/java/org/donggle/backend/domain/writing/WritingStatus.java
+++ b/backend/src/main/java/org/donggle/backend/domain/writing/WritingStatus.java
@@ -1,0 +1,7 @@
+package org.donggle.backend.domain.writing;
+
+public enum WritingStatus {
+    ACTIVE,
+    TRASHED,
+    DELETED
+}

--- a/backend/src/main/java/org/donggle/backend/exception/notfound/DeleteWritingNotFoundException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/notfound/DeleteWritingNotFoundException.java
@@ -1,0 +1,21 @@
+package org.donggle.backend.exception.notfound;
+
+public class DeleteWritingNotFoundException extends NotFoundException {
+    private static final String MESSAGE = "삭제할 글을 찾을 수 없습니다.";
+    private final Long writingId;
+
+    public DeleteWritingNotFoundException(final Long writingId) {
+        super(MESSAGE);
+        this.writingId = writingId;
+    }
+
+    public DeleteWritingNotFoundException(final Long writingId, final Throwable cause) {
+        super(MESSAGE, cause);
+        this.writingId = writingId;
+    }
+
+    @Override
+    public String getHint() {
+        return "해당 글을 찾을 수 없습니다. 입력 id: " + writingId;
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/exception/notfound/DeleteWritingNotFoundException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/notfound/DeleteWritingNotFoundException.java
@@ -2,6 +2,7 @@ package org.donggle.backend.exception.notfound;
 
 public class DeleteWritingNotFoundException extends NotFoundException {
     private static final String MESSAGE = "삭제할 글을 찾을 수 없습니다.";
+    
     private final Long writingId;
 
     public DeleteWritingNotFoundException(final Long writingId) {

--- a/backend/src/main/java/org/donggle/backend/exception/notfound/RestoreWritingNotFoundException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/notfound/RestoreWritingNotFoundException.java
@@ -1,0 +1,21 @@
+package org.donggle.backend.exception.notfound;
+
+public class RestoreWritingNotFoundException extends NotFoundException {
+    private static final String MESSAGE = "복구할 글을 찾을 수 없습니다.";
+    private final Long writingId;
+
+    public RestoreWritingNotFoundException(final Long writingId) {
+        super(MESSAGE);
+        this.writingId = writingId;
+    }
+
+    public RestoreWritingNotFoundException(final Long writingId, final Throwable cause) {
+        super(MESSAGE, cause);
+        this.writingId = writingId;
+    }
+
+    @Override
+    public String getHint() {
+        return "해당 글을 찾을 수 없습니다. 입력 id: " + writingId;
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/exception/notfound/RestoreWritingNotFoundException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/notfound/RestoreWritingNotFoundException.java
@@ -2,6 +2,7 @@ package org.donggle.backend.exception.notfound;
 
 public class RestoreWritingNotFoundException extends NotFoundException {
     private static final String MESSAGE = "복구할 글을 찾을 수 없습니다.";
+    
     private final Long writingId;
 
     public RestoreWritingNotFoundException(final Long writingId) {

--- a/backend/src/main/java/org/donggle/backend/exception/notfound/WritingNotFoundException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/notfound/WritingNotFoundException.java
@@ -15,11 +15,6 @@ public class WritingNotFoundException extends NotFoundException {
         this.writingId = writingId;
     }
 
-    public WritingNotFoundException(final Long writingId, final String message) {
-        super(message);
-        this.writingId = writingId;
-    }
-
     @Override
     public String getHint() {
         return "해당 글을 찾을 수 없습니다. 입력 id: " + writingId;

--- a/backend/src/main/java/org/donggle/backend/exception/notfound/WritingNotFoundException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/notfound/WritingNotFoundException.java
@@ -2,19 +2,24 @@ package org.donggle.backend.exception.notfound;
 
 public class WritingNotFoundException extends NotFoundException {
     private static final String MESSAGE = "존재하지 않는 글입니다.";
-    
+
     private final Long writingId;
-    
+
     public WritingNotFoundException(final Long writingId) {
         super(MESSAGE);
         this.writingId = writingId;
     }
-    
+
     public WritingNotFoundException(final Long writingId, final Throwable cause) {
         super(MESSAGE, cause);
         this.writingId = writingId;
     }
-    
+
+    public WritingNotFoundException(final Long writingId, final String message) {
+        super(message);
+        this.writingId = writingId;
+    }
+
     @Override
     public String getHint() {
         return "해당 글을 찾을 수 없습니다. 입력 id: " + writingId;

--- a/backend/src/main/java/org/donggle/backend/ui/TrashController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/TrashController.java
@@ -5,6 +5,7 @@ import org.donggle.backend.application.service.TrashService;
 import org.donggle.backend.application.service.request.DeleteWritingsRequest;
 import org.donggle.backend.application.service.request.RestoreWritingsRequest;
 import org.donggle.backend.auth.support.AuthenticationPrincipal;
+import org.donggle.backend.ui.response.TrashResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,9 +20,9 @@ public class TrashController {
     private final TrashService trashService;
 
     @GetMapping
-    public ResponseEntity<Void> trashGetWritings(@AuthenticationPrincipal final Long memberId) {
-        trashService.findTrashedWritingList(memberId);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<TrashResponse> trashGetWritings(@AuthenticationPrincipal final Long memberId) {
+        final TrashResponse trashResponse = trashService.findTrashedWritingList(memberId);
+        return ResponseEntity.ok(trashResponse);
     }
 
     @PostMapping

--- a/backend/src/main/java/org/donggle/backend/ui/TrashController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/TrashController.java
@@ -1,6 +1,7 @@
 package org.donggle.backend.ui;
 
 import lombok.RequiredArgsConstructor;
+import org.donggle.backend.application.service.TrashService;
 import org.donggle.backend.application.service.request.DeleteWritingsRequest;
 import org.donggle.backend.application.service.request.RestoreWritingsRequest;
 import org.donggle.backend.auth.support.AuthenticationPrincipal;
@@ -15,20 +16,29 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/trash")
 public class TrashController {
+    private final TrashService trashService;
+
     @GetMapping
     public ResponseEntity<Void> trashGetWritings(@AuthenticationPrincipal final Long memberId) {
+        trashService.findTrashedWritingList(memberId);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping
     public ResponseEntity<Void> trashDeleteWritings(@AuthenticationPrincipal final Long memberId,
                                                     @RequestBody final DeleteWritingsRequest request) {
+        if (request.isPermanentDelete()) {
+            trashService.deleteWritings(memberId, request.writingIds());
+        } else {
+            trashService.trashWritings(memberId, request.writingIds());
+        }
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/restore")
     public ResponseEntity<Void> trashRestoreWritings(@AuthenticationPrincipal final Long memberId,
                                                      @RequestBody final RestoreWritingsRequest request) {
+        trashService.restoreWritings(memberId, request.writingIds());
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/org/donggle/backend/ui/TrashController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/TrashController.java
@@ -1,0 +1,34 @@
+package org.donggle.backend.ui;
+
+import lombok.RequiredArgsConstructor;
+import org.donggle.backend.application.service.request.DeleteWritingsRequest;
+import org.donggle.backend.application.service.request.RestoreWritingsRequest;
+import org.donggle.backend.auth.support.AuthenticationPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trash")
+public class TrashController {
+    @GetMapping
+    public ResponseEntity<Void> trashGetWritings(@AuthenticationPrincipal final Long memberId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> trashDeleteWritings(@AuthenticationPrincipal final Long memberId,
+                                                    @RequestBody final DeleteWritingsRequest request) {
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/restore")
+    public ResponseEntity<Void> trashRestoreWritings(@AuthenticationPrincipal final Long memberId,
+                                                     @RequestBody final RestoreWritingsRequest request) {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/ui/response/TrashResponse.java
+++ b/backend/src/main/java/org/donggle/backend/ui/response/TrashResponse.java
@@ -1,0 +1,17 @@
+package org.donggle.backend.ui.response;
+
+import org.donggle.backend.domain.writing.Writing;
+
+import java.util.List;
+
+public record TrashResponse(
+        List<TrashedWritingResponse> writings
+) {
+    public static TrashResponse from(final List<Writing> trashedWritings) {
+        return new TrashResponse(
+                trashedWritings.stream()
+                        .map(TrashedWritingResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/ui/response/TrashedWritingResponse.java
+++ b/backend/src/main/java/org/donggle/backend/ui/response/TrashedWritingResponse.java
@@ -1,0 +1,17 @@
+package org.donggle.backend.ui.response;
+
+import org.donggle.backend.domain.writing.Writing;
+
+public record TrashedWritingResponse(
+        Long id,
+        String title,
+        Long categoryId
+) {
+    public static TrashedWritingResponse from(final Writing trashedWriting) {
+        return new TrashedWritingResponse(
+                trashedWriting.getId(),
+                trashedWriting.getTitleValue(),
+                trashedWriting.getCategory().getId()
+        );
+    }
+}

--- a/backend/src/test/java/org/donggle/backend/application/service/TrashServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/TrashServiceTest.java
@@ -1,0 +1,151 @@
+package org.donggle.backend.application.service;
+
+import jakarta.transaction.Transactional;
+import org.donggle.backend.application.repository.CategoryRepository;
+import org.donggle.backend.application.repository.MemberRepository;
+import org.donggle.backend.application.repository.WritingRepository;
+import org.donggle.backend.domain.category.Category;
+import org.donggle.backend.domain.member.Member;
+import org.donggle.backend.domain.writing.Title;
+import org.donggle.backend.domain.writing.Writing;
+import org.donggle.backend.ui.response.TrashResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Transactional
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class TrashServiceTest {
+    @Autowired
+    private WritingRepository writingRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private TrashService trashService;
+
+    @BeforeEach
+    void setUp() {
+        final Writing writing1 = writingRepository.findById(1L).get();
+        final Member member = memberRepository.findById(1L).get();
+        final Category category = categoryRepository.findFirstByMemberId(1L).get();
+        final Writing writing2 = Writing.of(member, new Title("test2"), category, null);
+        final Writing writing3 = Writing.of(member, new Title("test3"), category, null);
+        final Writing writing4 = Writing.of(member, new Title("test4"), category, null);
+        writingRepository.save(writing2);
+        writingRepository.save(writing3);
+        writingRepository.save(writing4);
+        writing1.changeNextWriting(writing2);
+        writing2.changeNextWriting(writing3);
+        writing3.changeNextWriting(writing4);
+    }
+
+    @Test
+    @DisplayName("쓰레기통에 있는 글을 조회한다.")
+    void findTrashedWritingList() {
+        //given
+        final Writing writing = writingRepository.findById(1L).get();
+        writing.moveToTrash();
+
+        //when
+        final TrashResponse trashResponse = trashService.findTrashedWritingList(1L);
+
+        //then
+        assertAll(
+                () -> assertThat(trashResponse.writings()).hasSize(1),
+                () -> assertThat(trashResponse.writings()).usingRecursiveComparison()
+                        .comparingOnlyFields("id")
+                        .isEqualTo(writing.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("쓰레기통으로 글을 옮긴 뒤 원래 글의 순서를 변경한다. - 가운데")
+    void changeOrderOfTrashedWritingsMiddle() {
+        //given
+        //when
+        trashService.trashWritings(1L, List.of(3L));
+
+        //then
+        final List<Writing> writings = writingRepository.findAllByCategoryId(1L);
+        assertAll(
+                () -> assertThat(writings).hasSize(3),
+                () -> assertThat(writings.get(0).getNextWriting()).isEqualTo(writings.get(1))
+        );
+    }
+
+    @Test
+    @DisplayName("쓰레기통으로 글을 옮긴 뒤 원래 글의 순서를 변경한다. - 마지막")
+    void changeOrderOfTrashedWritingsLast() {
+        //given
+        final Writing writing = writingRepository.findById(4L).get();
+        //when
+        trashService.trashWritings(1L, List.of(writing.getId()));
+
+        //then
+        final List<Writing> writings = writingRepository.findAllByCategoryId(1L);
+        assertAll(
+                () -> assertThat(writings).hasSize(3),
+                () -> assertThat(writings.get(0).getNextWriting()).isEqualTo(writings.get(1))
+        );
+    }
+
+    @Test
+    @DisplayName("쓰레기통으로 글을 옮긴 뒤 원래 글의 순서를 변경한다. - 첫번째")
+    void changeOrderOfTrashedWritingsFirst() {
+        //given
+        final Writing writing = writingRepository.findById(1L).get();
+        //when
+        trashService.trashWritings(1L, List.of(writing.getId()));
+
+        //then
+        final List<Writing> writings = writingRepository.findAllByCategoryId(1L);
+        assertAll(
+                () -> assertThat(writings).hasSize(3),
+                () -> assertThat(writings.get(0).getNextWriting()).isEqualTo(writings.get(1))
+        );
+    }
+
+    @Test
+    @DisplayName("글을 삭제한다.")
+    void deleteWritings() {
+        //given
+
+        //when
+        trashService.deleteWritings(1L, List.of(1L));
+
+        //then
+        assertThat(writingRepository.findById(1L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("쓰레기통에 있는 글을 복원한다.")
+    void restoreWritings() {
+        //given
+        final Writing writing = writingRepository.findById(1L).get();
+        writing.moveToTrash();
+
+        //when
+        trashService.restoreWritings(1L, List.of(1L));
+
+        //then
+        final List<Writing> writings = writingRepository.findAllByCategoryId(1L);
+        final Optional<Writing> restoredWriting = writingRepository.findById(1L);
+        assertAll(
+                () -> assertThat(restoredWriting).isNotEmpty(),
+                () -> assertThat(writings).hasSize(4),
+                () -> assertThat(restoredWriting.get().getNextWriting()).isNull()
+        );
+    }
+}

--- a/backend/src/test/java/org/donggle/backend/application/service/TrashServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/TrashServiceTest.java
@@ -90,6 +90,7 @@ class TrashServiceTest {
     void changeOrderOfTrashedWritingsLast() {
         //given
         final Writing writing = writingRepository.findById(4L).get();
+        
         //when
         trashService.trashWritings(1L, List.of(writing.getId()));
 


### PR DESCRIPTION
### 🛠️ Issue

- close #280 

### ✅ Tasks
- [x] 휴지통 서비스 구현
- [x] 글 소프트 삭제 구현
- [x] 글 휴지통 상태 구현

### ⏰ Time Difference
- 1

### 📝 Note
- Writing에 `@SQLDelete(sql = "UPDATE writing SET status = 'DELETED' WHERE id = ?")`로 `repository.delete`로 엔티티 삭제시 status를 DELETED로 변경하도록 하였습니다.
- Writing에 `@Where(clause = "status = 'ACTIVE'")`를 추가하여 기존 repository 메서드 변경 없이 사용할 수 있도록 하였습니다. 예를 들어 findById로 writing을 찾을시 status=ACTIVE인 writing만 찾아올 것입니다.
- status=TRASHED,DELETED일 경우에는 @Query에 nativequery를 사용하여 찾아오도록 하였습니다.
