### PR TITLE
[BE] feat: MemberPage 조회 API 구현

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
@@ -20,8 +20,10 @@ public class MemberService {
     private final MemberCredentialsRepository memberCredentialsRepository;
 
     public MemberPageResponse findMemberPage(final Long memberId) {
-        final Member foundMember = memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
-        final MemberCredentials foundMemberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(foundMember).orElseThrow(NoSuchElementException::new);
+        final Member foundMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        final MemberCredentials foundMemberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(foundMember)
+                .orElseThrow(NoSuchElementException::new);
         return MemberPageResponse.from(foundMember, foundMemberCredentials);
     }
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
@@ -19,11 +19,12 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberCredentialsRepository memberCredentialsRepository;
 
+    @Transactional(readOnly = true)
     public MemberPageResponse findMemberPage(final Long memberId) {
         final Member foundMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
         final MemberCredentials foundMemberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(foundMember)
                 .orElseThrow(NoSuchElementException::new);
-        return MemberPageResponse.from(foundMember, foundMemberCredentials);
+        return MemberPageResponse.of(foundMember, foundMemberCredentials);
     }
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
@@ -1,0 +1,27 @@
+package org.donggle.backend.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.donggle.backend.application.repository.MemberCredentialsRepository;
+import org.donggle.backend.application.repository.MemberRepository;
+import org.donggle.backend.domain.member.Member;
+import org.donggle.backend.domain.member.MemberCredentials;
+import org.donggle.backend.exception.notfound.MemberNotFoundException;
+import org.donggle.backend.ui.response.MemberPageResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final MemberCredentialsRepository memberCredentialsRepository;
+
+    public MemberPageResponse findMemberPage(final Long memberId) {
+        final Member foundMember = memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+        final MemberCredentials foundMemberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(foundMember).orElseThrow(NoSuchElementException::new);
+        return MemberPageResponse.from(foundMember, foundMemberCredentials);
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/application/service/PublishService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/PublishService.java
@@ -29,6 +29,7 @@ import org.donggle.backend.exception.business.MediumNotConnectedException;
 import org.donggle.backend.exception.business.TistoryNotConnectedException;
 import org.donggle.backend.exception.business.WritingAlreadyPublishedException;
 import org.donggle.backend.exception.notfound.BlogNotFoundException;
+import org.donggle.backend.exception.notfound.MemberNotFoundException;
 import org.donggle.backend.exception.notfound.WritingNotFoundException;
 import org.springframework.stereotype.Service;
 
@@ -51,7 +52,7 @@ public class PublishService {
     public void publishWriting(final Long memberId, final Long writingId, final PublishRequest publishRequest) {
         final Blog blog = findBlog(publishRequest);
         final Writing writing = findWriting(writingId);
-        final Member member = memberRepository.findById(memberId).orElseThrow();
+        final Member member = findMember(memberId);
 
         final List<BlogWriting> publishedBlogs = blogWritingRepository.findByWritingId(writingId);
         publishedBlogs.forEach(publishedBlog -> checkWritingAlreadyPublished(publishedBlog, blog.getBlogType(), writing));
@@ -119,6 +120,11 @@ public class PublishService {
     private MemberCredentials findMemberCredentials(final Member member) {
         return memberCredentialsRepository.findMemberCredentialsByMember(member)
                 .orElseThrow(NoSuchElementException::new);
+    }
+
+    private Member findMember(final Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
     }
 
     private Writing findWriting(final Long writingId) {

--- a/backend/src/main/java/org/donggle/backend/application/service/WritingService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/WritingService.java
@@ -61,7 +61,6 @@ public class WritingService {
     private final CategoryRepository categoryRepository;
 
     public Long uploadMarkDownFile(final Long memberId, final MarkdownUploadRequest request) throws IOException {
-        //TODO: member checking
         final String originalFilename = request.file().getOriginalFilename();
         if (!Objects.requireNonNull(originalFilename).endsWith(MD_FORMAT)) {
             throw new InvalidFileFormatException(originalFilename);

--- a/backend/src/main/java/org/donggle/backend/application/service/WritingService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/WritingService.java
@@ -25,6 +25,7 @@ import org.donggle.backend.domain.writing.Title;
 import org.donggle.backend.domain.writing.Writing;
 import org.donggle.backend.domain.writing.content.Block;
 import org.donggle.backend.exception.business.InvalidFileFormatException;
+import org.donggle.backend.exception.business.NotionNotConnectedException;
 import org.donggle.backend.exception.notfound.CategoryNotFoundException;
 import org.donggle.backend.exception.notfound.MemberNotFoundException;
 import org.donggle.backend.exception.notfound.WritingNotFoundException;
@@ -84,12 +85,11 @@ public class WritingService {
     }
 
     public Long uploadNotionPage(final Long memberId, final NotionUploadRequest request) {
-        // TODO : authentication 후 member 객체 가져오도록 수정
-        // TODO : MemberCredential에서 값 못찾을 경우 예외던지기
         final Member findMember = findMember(memberId);
         final Category findCategory = findCategory(request.categoryId());
         final MemberCredentials memberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(findMember).orElseThrow();
-        final String notionToken = memberCredentials.getNotionToken();
+        final String notionToken = memberCredentials.getNotionToken()
+                .orElseThrow(NotionNotConnectedException::new);
         final NotionApiService notionApiService = new NotionApiService();
 
         final String blockId = request.blockId();

--- a/backend/src/main/java/org/donggle/backend/domain/member/MemberCredentials.java
+++ b/backend/src/main/java/org/donggle/backend/domain/member/MemberCredentials.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import org.donggle.backend.domain.common.BaseEntity;
 
 import java.util.Objects;
+import java.util.Optional;
 
 @Entity
 @Getter
@@ -60,6 +61,34 @@ public class MemberCredentials extends BaseEntity {
 
     public void updateNotionToken(final String notionToken) {
         this.notionToken = notionToken;
+    }
+
+    public boolean isTistoryConnected() {
+        return getTistoryToken().isPresent() && getTistoryBlogName().isPresent();
+    }
+
+    public boolean isMediumConnected() {
+        return getMediumToken().isPresent();
+    }
+
+    public boolean isNotionConnected() {
+        return getNotionToken().isPresent();
+    }
+
+    public Optional<String> getTistoryToken() {
+        return Optional.ofNullable(tistoryToken);
+    }
+
+    public Optional<String> getTistoryBlogName() {
+        return Optional.ofNullable(tistoryBlogName);
+    }
+
+    public Optional<String> getMediumToken() {
+        return Optional.ofNullable(mediumToken);
+    }
+
+    public Optional<String> getNotionToken() {
+        return Optional.ofNullable(notionToken);
     }
 
     @Override

--- a/backend/src/main/java/org/donggle/backend/exception/business/MediumNotConnectedException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/business/MediumNotConnectedException.java
@@ -1,0 +1,25 @@
+package org.donggle.backend.exception.business;
+
+import org.springframework.http.HttpStatus;
+
+public class MediumNotConnectedException extends BusinessException {
+    private static final String MESSAGE = "미디엄 연동이 되어있지 않습니다.";
+
+    public MediumNotConnectedException() {
+        super(MESSAGE);
+    }
+
+    public MediumNotConnectedException(final Throwable cause) {
+        super(MESSAGE, cause);
+    }
+
+    @Override
+    public String getHint() {
+        return "미디움을 연동해주세요.";
+    }
+
+    @Override
+    public int getErrorCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/exception/business/NotionNotConnectedException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/business/NotionNotConnectedException.java
@@ -1,0 +1,25 @@
+package org.donggle.backend.exception.business;
+
+import org.springframework.http.HttpStatus;
+
+public class NotionNotConnectedException extends BusinessException {
+    private static final String MESSAGE = "노션 연동이 되어있지 않습니다.";
+
+    public NotionNotConnectedException() {
+        super(MESSAGE);
+    }
+
+    public NotionNotConnectedException(final Throwable cause) {
+        super(MESSAGE, cause);
+    }
+
+    @Override
+    public String getHint() {
+        return "노션을 연동해주세요.";
+    }
+
+    @Override
+    public int getErrorCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/exception/business/TistoryNotConnectedException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/business/TistoryNotConnectedException.java
@@ -15,7 +15,7 @@ public class TistoryNotConnectedException extends BusinessException {
 
     @Override
     public String getHint() {
-        return "티스토리 연동을 먼저 해주세요.";
+        return "티스토리 연동을 해주세요.";
     }
 
     @Override

--- a/backend/src/main/java/org/donggle/backend/exception/business/TistoryNotConnectedException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/business/TistoryNotConnectedException.java
@@ -1,0 +1,25 @@
+package org.donggle.backend.exception.business;
+
+import org.springframework.http.HttpStatus;
+
+public class TistoryNotConnectedException extends BusinessException {
+    private static final String MESSAGE = "티스토리 연동이 되어있지 않습니다.";
+
+    public TistoryNotConnectedException() {
+        super(MESSAGE);
+    }
+
+    public TistoryNotConnectedException(final Throwable cause) {
+        super(MESSAGE, cause);
+    }
+
+    @Override
+    public String getHint() {
+        return "티스토리 연동을 먼저 해주세요.";
+    }
+
+    @Override
+    public int getErrorCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/ui/AuthController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/AuthController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/member")
+@RequestMapping("/auth")
 public class AuthController {
 
     private final int cookieTime;

--- a/backend/src/main/java/org/donggle/backend/ui/MemberController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/MemberController.java
@@ -1,0 +1,23 @@
+package org.donggle.backend.ui;
+
+import lombok.RequiredArgsConstructor;
+import org.donggle.backend.application.service.MemberService;
+import org.donggle.backend.auth.support.AuthenticationPrincipal;
+import org.donggle.backend.ui.response.MemberPageResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping
+    public ResponseEntity<MemberPageResponse> memberPage(@AuthenticationPrincipal final Long memberId) {
+        final MemberPageResponse memberPage = memberService.findMemberPage(memberId);
+        return ResponseEntity.ok(memberPage);
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/ui/config/WebMvcConfig.java
+++ b/backend/src/main/java/org/donggle/backend/ui/config/WebMvcConfig.java
@@ -40,7 +40,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .order(1);
 
         registry.addInterceptor(new AuthInterceptor(jwtTokenProvider))
-                .addPathPatterns("/member/**", "/writings/**", "/categories/**", "/trash/**", "/connections/**")
+                .addPathPatterns("/member/**", "/writings/**", "/categories/**", "/trash/**", "/connections/**", "/auth/**")
                 .order(2);
 
         registry.addInterceptor(new RefreshTokenAuthInterceptor(jwtTokenProvider, tokenRepository))

--- a/backend/src/main/java/org/donggle/backend/ui/response/MediumConnectionResponse.java
+++ b/backend/src/main/java/org/donggle/backend/ui/response/MediumConnectionResponse.java
@@ -1,0 +1,6 @@
+package org.donggle.backend.ui.response;
+
+public record MediumConnectionResponse(
+        boolean isConnected
+) {
+}

--- a/backend/src/main/java/org/donggle/backend/ui/response/MemberPageResponse.java
+++ b/backend/src/main/java/org/donggle/backend/ui/response/MemberPageResponse.java
@@ -1,0 +1,22 @@
+package org.donggle.backend.ui.response;
+
+import org.donggle.backend.domain.member.Member;
+import org.donggle.backend.domain.member.MemberCredentials;
+
+public record MemberPageResponse(
+        Long id,
+        String name,
+        TistoryConnectionResponse tistoryConnection,
+        NotionConnectionResponse notionConnection,
+        MediumConnectionResponse mediumConnection
+) {
+    public static MemberPageResponse from(final Member member, final MemberCredentials memberCredentials) {
+        return new MemberPageResponse(
+                member.getId(),
+                member.getMemberName().getName(),
+                new TistoryConnectionResponse(memberCredentials.isTistoryConnected(), memberCredentials.getTistoryBlogName().orElse(null)),
+                new NotionConnectionResponse(memberCredentials.isNotionConnected()),
+                new MediumConnectionResponse(memberCredentials.isMediumConnected())
+        );
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/ui/response/MemberPageResponse.java
+++ b/backend/src/main/java/org/donggle/backend/ui/response/MemberPageResponse.java
@@ -10,7 +10,7 @@ public record MemberPageResponse(
         NotionConnectionResponse notionConnection,
         MediumConnectionResponse mediumConnection
 ) {
-    public static MemberPageResponse from(final Member member, final MemberCredentials memberCredentials) {
+    public static MemberPageResponse of(final Member member, final MemberCredentials memberCredentials) {
         return new MemberPageResponse(
                 member.getId(),
                 member.getMemberName().getName(),

--- a/backend/src/main/java/org/donggle/backend/ui/response/NotionConnectionResponse.java
+++ b/backend/src/main/java/org/donggle/backend/ui/response/NotionConnectionResponse.java
@@ -1,0 +1,6 @@
+package org.donggle.backend.ui.response;
+
+public record NotionConnectionResponse(
+        boolean isConnected
+) {
+}

--- a/backend/src/main/java/org/donggle/backend/ui/response/TistoryConnectionResponse.java
+++ b/backend/src/main/java/org/donggle/backend/ui/response/TistoryConnectionResponse.java
@@ -1,0 +1,7 @@
+package org.donggle.backend.ui.response;
+
+public record TistoryConnectionResponse(
+        boolean isConnected,
+        String blogName
+) {
+}

--- a/backend/src/main/java/org/donggle/backend/ui/response/WritingResponse.java
+++ b/backend/src/main/java/org/donggle/backend/ui/response/WritingResponse.java
@@ -5,9 +5,10 @@ import org.donggle.backend.domain.writing.Writing;
 public record WritingResponse(
         Long id,
         String title,
-        String content
+        String content,
+        Long categoryId
 ) {
     public static WritingResponse of(final Writing writing, final String content) {
-        return new WritingResponse(writing.getId(), writing.getTitleValue(), content);
+        return new WritingResponse(writing.getId(), writing.getTitleValue(), content, writing.getCategory().getId());
     }
 }

--- a/backend/src/test/java/org/donggle/backend/application/service/MemberServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/MemberServiceTest.java
@@ -1,0 +1,67 @@
+package org.donggle.backend.application.service;
+
+import org.assertj.core.api.Assertions;
+import org.donggle.backend.application.repository.MemberCredentialsRepository;
+import org.donggle.backend.application.repository.MemberRepository;
+import org.donggle.backend.domain.member.Member;
+import org.donggle.backend.domain.member.MemberCredentials;
+import org.donggle.backend.ui.response.MemberPageResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MemberCredentialsRepository memberCredentialsRepository;
+
+    @Test
+    @DisplayName("회원 페이지 조회 - 아무것도 연결되어있지 않은 회원")
+    void findMemberPage() {
+        //given
+        final Member member = memberRepository.findById(1L).get();
+        final MemberCredentials savedMemberCredentials = memberCredentialsRepository.save(MemberCredentials.basic(member));
+        //when
+        final MemberPageResponse memberPage = memberService.findMemberPage(member.getId());
+
+        //then
+        assertAll(
+                () -> Assertions.assertThat(memberPage.id()).isEqualTo(member.getId()),
+                () -> Assertions.assertThat(memberPage.name()).isEqualTo(member.getMemberName().getName()),
+                () -> Assertions.assertThat(memberPage.tistoryConnection().isConnected()).isEqualTo(false),
+                () -> Assertions.assertThat(memberPage.tistoryConnection().blogName()).isNull(),
+                () -> Assertions.assertThat(memberPage.notionConnection().isConnected()).isEqualTo(false),
+                () -> Assertions.assertThat(memberPage.mediumConnection().isConnected()).isEqualTo(false)
+        );
+    }
+
+    @Test
+    @DisplayName("회원 페이지 조회 - 티스토리 연결된 회원")
+    void findMemberPage2() {
+        //given
+        final Member member = memberRepository.findById(1L).get();
+        final MemberCredentials savedMemberCredentials = memberCredentialsRepository.save(MemberCredentials.basic(member));
+        savedMemberCredentials.updateTistory("test", "test");
+        //when
+        final MemberPageResponse memberPage = memberService.findMemberPage(member.getId());
+
+        //then
+        assertAll(
+                () -> Assertions.assertThat(memberPage.id()).isEqualTo(member.getId()),
+                () -> Assertions.assertThat(memberPage.name()).isEqualTo(member.getMemberName().getName()),
+                () -> Assertions.assertThat(memberPage.tistoryConnection().isConnected()).isEqualTo(true),
+                () -> Assertions.assertThat(memberPage.tistoryConnection().blogName()).isEqualTo("test"),
+                () -> Assertions.assertThat(memberPage.notionConnection().isConnected()).isEqualTo(false),
+                () -> Assertions.assertThat(memberPage.mediumConnection().isConnected()).isEqualTo(false)
+        );
+    }
+}


### PR DESCRIPTION
### 🛠️ Issue

- close #298 

### ✅ Tasks
- [x] MemberPage를 조회하는 API 구현
- [x] WritingResponse에 CategoryId 필드 추가(아커 요청)

### ⏰ Time Difference
- 0
