### PR TITLE
[FE] feat: 전체적인 에러처리 코드 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import ToastProvider from 'contexts/ToastProvider';
 import ToastContainer from 'components/@common/Toast/ToastContainer';
 import { Outlet } from 'react-router-dom';
+import ErrorPage from 'pages/ErrorPage/ErrorPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -18,7 +19,7 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <ToastProvider>
-        <ErrorBoundary>
+        <ErrorBoundary fallback={ErrorPage}>
           <Outlet />
         </ErrorBoundary>
         <ToastContainer />

--- a/frontend/src/apis/fetch.ts
+++ b/frontend/src/apis/fetch.ts
@@ -21,7 +21,7 @@ const fetchAPI = async (endpoint: RequestInfo | URL, option: Option) => {
   try {
     const response = await fetch(endpoint, parseOption(option));
 
-    if (!response.ok) handleHttpError(response);
+    if (!response.ok) return handleHttpError(response);
 
     const contentType = response.headers.get('content-type');
 
@@ -32,7 +32,7 @@ const fetchAPI = async (endpoint: RequestInfo | URL, option: Option) => {
     // httpError 면 던져서 fetch API 사용하는 쪽에서 핸들링
     if (error instanceof HttpError) throw error;
 
-    alert(error); // httpError가 아니면 여기서 바로 alert
+    throw error; // httpError가 아니면 던지고 500 같은건 errorboundary errorPage에서 처리
   }
 };
 

--- a/frontend/src/components/@common/Modal/Modal.tsx
+++ b/frontend/src/components/@common/Modal/Modal.tsx
@@ -77,7 +77,6 @@ export default Modal;
 const S = {
   ModalWrapper: styled.div`
     position: relative;
-    z-index: 9999;
   `,
   Backdrop: styled.div`
     position: fixed;

--- a/frontend/src/components/Category/Category/Category.tsx
+++ b/frontend/src/components/Category/Category/Category.tsx
@@ -8,6 +8,7 @@ import Input from 'components/@common/Input/Input';
 import { isValidCategoryName } from '../isValidCategoryName';
 import DeleteButton from 'components/DeleteButton/DeleteButton';
 import { useToast } from 'hooks/@common/useToast';
+import { getErrorMessage } from 'utils/error';
 
 type Props = {
   categoryId: number;
@@ -49,8 +50,7 @@ const Category = ({ categoryId, categoryName, isDefaultCategory }: Props) => {
 
       resetInput();
     } catch (error) {
-      if (error instanceof Error)
-        toast.show({ type: 'error', message: error.message, hasProgressBar: true });
+      toast.show({ type: 'error', message: getErrorMessage(error), hasProgressBar: true });
     }
   };
 

--- a/frontend/src/components/Category/Category/Category.tsx
+++ b/frontend/src/components/Category/Category/Category.tsx
@@ -7,6 +7,7 @@ import { useCategoryMutation } from '../useCategoryMutation';
 import Input from 'components/@common/Input/Input';
 import { isValidCategoryName } from '../isValidCategoryName';
 import DeleteButton from 'components/DeleteButton/DeleteButton';
+import { useToast } from 'hooks/@common/useToast';
 
 type Props = {
   categoryId: number;
@@ -26,25 +27,31 @@ const Category = ({ categoryId, categoryName, isDefaultCategory }: Props) => {
   } = useCategoryInput('');
   const { patchCategory, deleteCategory } = useCategoryMutation();
   const { goWritingTablePage } = usePageNavigate();
+  const toast = useToast();
 
   const requestChangedName: KeyboardEventHandler<HTMLInputElement> = (e) => {
-    if (e.key !== 'Enter') return;
+    try {
+      if (e.key !== 'Enter') return;
 
-    const categoryName = e.currentTarget.value.trim();
+      const categoryName = e.currentTarget.value.trim();
 
-    if (!isValidCategoryName(categoryName)) {
-      setIsError(true);
-      return;
+      if (!isValidCategoryName(categoryName)) {
+        setIsError(true);
+        throw new Error('카테고리 이름은 1자 이상 31자 미만으로 입력해주세요.');
+      }
+
+      patchCategory({
+        categoryId,
+        body: {
+          categoryName,
+        },
+      });
+
+      resetInput();
+    } catch (error) {
+      if (error instanceof Error)
+        toast.show({ type: 'error', message: error.message, hasProgressBar: true });
     }
-
-    patchCategory({
-      categoryId,
-      body: {
-        categoryName,
-      },
-    });
-
-    resetInput();
   };
 
   return (

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -6,6 +6,7 @@ export type ErrorBoundaryFallbackProps = {
   status?: number;
   title: string;
   message: string;
+  onResetError?: () => void;
 };
 
 type Props = {
@@ -25,6 +26,17 @@ export class ErrorBoundary extends Component<Props, State> {
     this.state = { error: null };
   }
 
+  // 원래 렌더링을 보여주기 위해 Error 리셋
+  resetError() {
+    this.state.error && this.setState({ error: null });
+  }
+
+  componentDidUpdate(_: Readonly<Props>, prevState: Readonly<State>): void {
+    if (prevState.error === this.state.error) {
+      this.resetError();
+    }
+  }
+
   // 다음 렌더링에서 폴백 UI가 보이도록 상태를 업데이트
   static getDerivedStateFromError(error: Error) {
     return { error: error || null };
@@ -36,11 +48,13 @@ export class ErrorBoundary extends Component<Props, State> {
 
     if (this.state.error) {
       const error = this.state.error;
+
       if (error instanceof HttpError && fallback) {
         return React.createElement(fallback, {
           status: error.statusCode,
           title: '',
           message: error.message,
+          onResetError: this.resetError.bind(this),
         });
       }
     }

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,9 +2,15 @@ import { HttpStatus } from 'constants/apis/http';
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { HttpError } from 'utils/apis/HttpError';
 
+export type ErrorBoundaryFallbackProps = {
+  status?: number;
+  title: string;
+  message: string;
+};
+
 type Props = {
   children: ReactNode;
-  fallback?: ReactNode;
+  fallback?: React.FunctionComponent<ErrorBoundaryFallbackProps>;
   onReset?: VoidFunction;
 };
 
@@ -26,10 +32,16 @@ export class ErrorBoundary extends Component<Props, State> {
 
   // You can render any custom fallback UI
   render() {
+    const { fallback } = this.props;
+
     if (this.state.error) {
       const error = this.state.error;
-      if (error instanceof HttpError) {
-        alert(error.message);
+      if (error instanceof HttpError && fallback) {
+        return React.createElement(fallback, {
+          status: error.statusCode,
+          title: '',
+          message: error.message,
+        });
       }
     }
 

--- a/frontend/src/components/FileUploadModal/useFileUploadModal.ts
+++ b/frontend/src/components/FileUploadModal/useFileUploadModal.ts
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { addNotionWriting, addWriting } from 'apis/writings';
+import { useToast } from 'hooks/@common/useToast';
 import { usePageNavigate } from 'hooks/usePageNavigate';
 import { ChangeEventHandler, useState } from 'react';
 import { getErrorMessage } from 'utils/error';
@@ -11,11 +12,17 @@ type Args = {
 
 export const useFileUploadModal = ({ categoryId, closeModal }: Args) => {
   const [inputValue, setInputValue] = useState('');
+  const toast = useToast();
   const { goWritingPage } = usePageNavigate();
   const selectedCategoryId = categoryId ?? 1;
 
   const { mutate: uploadNotion, isLoading: isNotionUploadLoading } = useMutation(addNotionWriting, {
-    onSuccess: (data) => onFileUploadSuccess(data.headers),
+    onSuccess: (data) => {
+      onFileUploadSuccess(data.headers);
+    },
+    onError: (error) => {
+      toast.show({ type: 'error', message: getErrorMessage(error), hasProgressBar: true });
+    },
   });
 
   const { mutate: uploadFile, isLoading: isFileUploadLoading } = useMutation(addWriting, {

--- a/frontend/src/components/FileUploadModal/useFileUploadModal.ts
+++ b/frontend/src/components/FileUploadModal/useFileUploadModal.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { addNotionWriting, addWriting } from 'apis/writings';
 import { usePageNavigate } from 'hooks/usePageNavigate';
 import { ChangeEventHandler, useState } from 'react';
+import { getErrorMessage } from 'utils/error';
 
 type Args = {
   categoryId: number | null;
@@ -40,16 +41,22 @@ export const useFileUploadModal = ({ categoryId, closeModal }: Args) => {
   };
 
   const uploadNotionWriting = () => {
-    const blockId = inputValue.split('/')?.pop()?.split('?')?.shift()?.split('-').pop();
+    try {
+      const blockId = inputValue.split('/')?.pop()?.split('?')?.shift()?.split('-').pop();
 
-    if (!blockId) return;
+      if (!blockId) {
+        throw new Error('노션 페이지 링크를 입력해주세요.');
+      }
 
-    setInputValue('');
+      setInputValue('');
 
-    uploadNotion({
-      blockId: blockId,
-      categoryId: selectedCategoryId,
-    });
+      uploadNotion({
+        blockId: blockId,
+        categoryId: selectedCategoryId,
+      });
+    } catch (error) {
+      alert(getErrorMessage(error));
+    }
   };
 
   const isLoading = isNotionUploadLoading || isFileUploadLoading;

--- a/frontend/src/components/PublishingPropertySection/usePublishingPropertySection.ts
+++ b/frontend/src/components/PublishingPropertySection/usePublishingPropertySection.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { publishWriting as PublishWritingRequest } from 'apis/writings';
 import { TabKeys } from 'components/WritingSideBar/WritingSideBar';
+import { useToast } from 'hooks/@common/useToast';
 import { useState } from 'react';
 import { PublishWritingArgs } from 'types/apis/writings';
 import { Blog, PublishingPropertyData } from 'types/domain';
@@ -16,12 +17,15 @@ type PublishWritingToBlogArgs = {
 
 export const usePublishingPropertySection = ({ selectCurrentTab }: Args) => {
   const [propertyFormInfo, setPropertyFormInfo] = useState<PublishingPropertyData>({ tags: [] });
+  const toast = useToast();
   const { mutate: publishWriting, isLoading } = useMutation(PublishWritingRequest, {
     onSuccess: () => {
       selectCurrentTab(TabKeys.WritingProperty);
-      alert('글 발행에 성공했습니다.');
+      toast.show({ type: 'success', message: '글 발행에 성공했습니다.' });
     },
-    onError: () => alert('글 발행에 실패했습니다.'),
+    onError: () => {
+      toast.show({ type: 'error', message: '글 발행에 실패했습니다.' });
+    },
   });
 
   const publishWritingToBlog = ({ writingId, publishTo }: PublishWritingToBlogArgs) => {

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -1,4 +1,5 @@
 import { InputHTMLAttributes, useState } from 'react';
+import { getErrorMessage } from 'utils/error';
 
 export const useFileUpload = (accept: InputHTMLAttributes<HTMLInputElement>['accept'] = '*') => {
   const [selectedFile, setSelectedFile] = useState<FormData | null>(null);
@@ -20,7 +21,7 @@ export const useFileUpload = (accept: InputHTMLAttributes<HTMLInputElement>['acc
 
       setSelectedFile(formData);
     } catch (error) {
-      if (error instanceof Error) alert(error.message);
+      alert(getErrorMessage(error));
     }
   };
 

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -4,21 +4,24 @@ export const useFileUpload = (accept: InputHTMLAttributes<HTMLInputElement>['acc
   const [selectedFile, setSelectedFile] = useState<FormData | null>(null);
 
   const onFileChange = (e: React.DragEvent | Event) => {
-    const target = 'dataTransfer' in e ? e.dataTransfer : (e.target as HTMLInputElement);
+    try {
+      const target = 'dataTransfer' in e ? e.dataTransfer : (e.target as HTMLInputElement);
 
-    if (!target.files) return;
+      if (!target.files) return;
 
-    const newFile = target.files[0];
+      const newFile = target.files[0];
 
-    if (newFile.size > 5 * 1024 * 1024) {
-      alert('업로드 가능한 최대 용량은 5MB입니다. ');
-      return;
+      if (newFile.size > 5 * 1024 * 1024) {
+        throw new Error('업로드 가능한 최대 용량은 5MB입니다.');
+      }
+
+      const formData = new FormData();
+      formData.append('file', newFile);
+
+      setSelectedFile(formData);
+    } catch (error) {
+      if (error instanceof Error) alert(error.message);
     }
-
-    const formData = new FormData();
-    formData.append('file', newFile);
-
-    setSelectedFile(formData);
   };
 
   const openFinder = () => {

--- a/frontend/src/mocks/handlers/category.ts
+++ b/frontend/src/mocks/handlers/category.ts
@@ -13,7 +13,12 @@ export const categoryHandlers = [
   rest.post(categoryURL, (req, res, ctx) => {
     const body = req.body as AddCategoriesRequest;
 
-    if (!body || !body.categoryName) return res(ctx.delay(300), ctx.status(404));
+    if (!body || !body.categoryName)
+      return res(
+        ctx.delay(300),
+        ctx.status(404),
+        ctx.json({ message: '카테고리 이름은 공백이 될 수 없습니다.' }),
+      );
 
     return res(ctx.delay(300), ctx.set('Location', `/categories/200`), ctx.status(201));
   }),
@@ -22,7 +27,14 @@ export const categoryHandlers = [
   rest.get(`${categoryURL}/:categoryId`, (req, res, ctx) => {
     const categoryId = Number(req.params.categoryId);
 
-    if (categoryId !== 1 && categoryId !== 3) return res(ctx.delay(300), ctx.status(500));
+    if (categoryId !== 1 && categoryId !== 3)
+      return res(
+        ctx.delay(300),
+        ctx.status(500),
+        ctx.json({
+          message: '서버에서 예기치 못한 에러가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        }),
+      );
 
     if (categoryId === 1) return res(ctx.json(writingsInCategory), ctx.delay(300), ctx.status(200));
 
@@ -33,7 +45,14 @@ export const categoryHandlers = [
   rest.patch(`${categoryURL}/:categoryId`, (req, res, ctx) => {
     const categoryName = req.body as PatchCategory;
 
-    if (!categoryName) return res(ctx.delay(300), ctx.status(404));
+    if (!categoryName)
+      return res(
+        ctx.delay(300),
+        ctx.status(404),
+        ctx.json({
+          message: '카테고리 이름 수정 에러',
+        }),
+      );
 
     return res(ctx.delay(300), ctx.status(204));
   }),
@@ -42,7 +61,14 @@ export const categoryHandlers = [
   rest.patch(`${categoryURL}/:categoryId`, (req, res, ctx) => {
     const nextCategoryId = req.body as PatchCategory;
 
-    if (!nextCategoryId) return res(ctx.delay(300), ctx.status(404));
+    if (!nextCategoryId)
+      return res(
+        ctx.delay(300),
+        ctx.status(404),
+        ctx.json({
+          message: '카테고리 경로 수정 에러',
+        }),
+      );
 
     return res(ctx.delay(300), ctx.status(204));
   }),

--- a/frontend/src/mocks/handlers/writing.ts
+++ b/frontend/src/mocks/handlers/writing.ts
@@ -80,7 +80,13 @@ export const writingHandlers = [
     const id = Number(req.params.writingId);
     const { publishTo } = await req.json();
 
-    if (!blog.includes(publishTo) || typeof id !== 'number') return res(ctx.status(404));
+    if (!blog.includes(publishTo) || typeof id !== 'number')
+      return res(
+        ctx.status(404),
+        ctx.json({
+          message: '글 발행을 실패했습니다.',
+        }),
+      );
 
     return res(ctx.delay(3000), ctx.status(200));
   }),

--- a/frontend/src/mocks/handlers/writing.ts
+++ b/frontend/src/mocks/handlers/writing.ts
@@ -62,7 +62,12 @@ export const writingHandlers = [
 
   // 글 생성(글 업로드): POST
   rest.post(`${writingURL}/notion`, async (_, res, ctx) => {
-    return res(ctx.delay(3000), ctx.status(201), ctx.set('Location', `/writings/200`));
+    // return res(ctx.delay(1000), ctx.status(201), ctx.set('Location', `/writings/200`));
+    return res(
+      ctx.delay(1000),
+      ctx.status(404),
+      ctx.json({ message: '유효한 노션 id를 입력해주세요.' }),
+    );
   }),
 
   // 글 블로그로 발행: POST

--- a/frontend/src/mocks/handlers/writing.ts
+++ b/frontend/src/mocks/handlers/writing.ts
@@ -24,7 +24,7 @@ export const writingHandlers = [
         }),
       );
     }
-    return res(ctx.delay(300), ctx.status(404));
+    return res(ctx.delay(300), ctx.status(404), ctx.json({ message: '글을 찾을 수 없습니다.' }));
   }),
 
   // 글 정보: GET
@@ -52,7 +52,11 @@ export const writingHandlers = [
         }),
       );
     }
-    return res(ctx.delay(300), ctx.status(404));
+    return res(
+      ctx.delay(300),
+      ctx.status(404),
+      ctx.json({ message: '글 정보를 찾을 수 없습니다.' }),
+    );
   }),
 
   // 글 생성(글 업로드): POST

--- a/frontend/src/pages/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,0 +1,46 @@
+import Button from 'components/@common/Button/Button';
+import { useNavigate } from 'react-router-dom';
+import { styled } from 'styled-components';
+
+const ErrorPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <S.Container>
+      <S.Status>404 Error</S.Status>
+      <S.ErrorMessageContainer>
+        <p>요청하신 페이지를 찾을 수 없습니다.</p>
+        <p>입력하신 주소가 정확한지 다시 한번 확인해주세요.</p>
+      </S.ErrorMessageContainer>
+      <Button variant='text' onClick={() => navigate(-1)}>
+        이전 페이지로 돌아가기
+      </Button>
+    </S.Container>
+  );
+};
+
+export default ErrorPage;
+
+const S = {
+  Container: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100vw;
+    height: 100vh;
+    gap: 1rem;
+  `,
+
+  Status: styled.h1`
+    font-size: 6rem;
+    color: ${({ theme }) => theme.color.gray10};
+  `,
+
+  ErrorMessageContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-size: 1.5rem;
+  `,
+};

--- a/frontend/src/pages/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,10 +1,15 @@
 import Button from 'components/@common/Button/Button';
 import { ErrorBoundaryFallbackProps } from 'components/ErrorBoundary/ErrorBoundary';
-import { useNavigate } from 'react-router-dom';
+import { usePageNavigate } from 'hooks/usePageNavigate';
 import { styled } from 'styled-components';
 
-const ErrorPage = ({ status, title, message }: ErrorBoundaryFallbackProps) => {
-  const navigate = useNavigate();
+const ErrorPage = ({ status, title, message, onResetError }: ErrorBoundaryFallbackProps) => {
+  const { goHomePage } = usePageNavigate();
+
+  const handleGoHomePage = () => {
+    onResetError?.();
+    goHomePage();
+  };
 
   return (
     <S.Container>
@@ -13,8 +18,8 @@ const ErrorPage = ({ status, title, message }: ErrorBoundaryFallbackProps) => {
         <p>요청하신 페이지를 찾을 수 없습니다.</p>
         <p>{message}</p>
       </S.ErrorMessageContainer>
-      <Button variant='text' onClick={() => navigate(-1)}>
-        이전 페이지로 돌아가기
+      <Button variant='text' onClick={handleGoHomePage}>
+        스페이스로 돌아가기
       </Button>
     </S.Container>
   );

--- a/frontend/src/pages/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,16 +1,17 @@
 import Button from 'components/@common/Button/Button';
+import { ErrorBoundaryFallbackProps } from 'components/ErrorBoundary/ErrorBoundary';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-const ErrorPage = () => {
+const ErrorPage = ({ status, title, message }: ErrorBoundaryFallbackProps) => {
   const navigate = useNavigate();
 
   return (
     <S.Container>
-      <S.Status>404 Error</S.Status>
+      <S.Status>{status} Error</S.Status>
       <S.ErrorMessageContainer>
         <p>요청하신 페이지를 찾을 수 없습니다.</p>
-        <p>입력하신 주소가 정확한지 다시 한번 확인해주세요.</p>
+        <p>{message}</p>
       </S.ErrorMessageContainer>
       <Button variant='text' onClick={() => navigate(-1)}>
         이전 페이지로 돌아가기

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -6,6 +6,7 @@ import OauthPage from 'pages/OauthPage/OauthPage';
 import IntroducePage from 'pages/IntroducePage/IntroducePage';
 import Layout from 'pages/Layout/Layout';
 import { PATH } from 'constants/path';
+import ErrorPage from 'pages/ErrorPage/ErrorPage';
 import TrashCanPage from 'pages/TrashCanPage/TrashCanPage';
 
 export const Router = () => {
@@ -46,6 +47,10 @@ export const Router = () => {
           ],
         },
       ],
+    },
+    {
+      path: '*',
+      element: <ErrorPage />,
     },
   ]);
 

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -50,7 +50,7 @@ export const Router = () => {
     },
     {
       path: '*',
-      element: <ErrorPage />,
+      element: <ErrorPage status={404} title='' message='' />,
     },
   ]);
 

--- a/frontend/src/utils/apis/HttpError.ts
+++ b/frontend/src/utils/apis/HttpError.ts
@@ -12,16 +12,18 @@ export class HttpError extends Error {
   }
 }
 
-export const handleHttpError = (response: Response) => {
+export const handleHttpError = async (response: Response) => {
   const statusCode = response.status;
+  const responseBody: { message: string } = await response.json();
+  const errorMessage = responseBody.message;
 
   if (statusCode >= HttpStatus.INTERNAL_SERVER_ERROR) {
-    throw new HttpError(statusCode);
+    throw new HttpError(statusCode, errorMessage);
   }
   if (statusCode >= HttpStatus.BAD_REQUEST) {
-    throw new HttpError(statusCode);
+    throw new HttpError(statusCode, errorMessage);
   }
   if (statusCode >= HttpStatus.MULTIPLE_CHOICES) {
-    throw new HttpError(statusCode);
+    throw new HttpError(statusCode, errorMessage);
   }
 };

--- a/frontend/src/utils/error.ts
+++ b/frontend/src/utils/error.ts
@@ -1,0 +1,5 @@
+export const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+};


### PR DESCRIPTION
### 🛠️ Issue

- close #262

### ✅ Tasks
- `App`의 ErrorBoundary는 중간에 handling되지 않은 httpError를 잡아서 `ErrorPage`를 렌더링합니다
- 3,4,500대 상태코드 error는 커스텀 Error인 `httpError`로 감싸져서 throw됩니다.
- 상태코드 에러가 아닌 에러들은 try catch로 감싸서 alert이나 toast로 보여줍니다.
  - 추후 alert과 toast를 보여주는 기준을 정해야할 것 같습니다. 
  - 각 throw 하는 부분은 validate~ 함수로 리팩터링 하면 좋을 것 같습니다.

### ⏰ Time Difference
- 10 + 6

### 📝 Note
- 
