### PR TITLE
[BE] fix: query의 `Writing` -> `writing`으로 키워드 변경

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -26,18 +26,18 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
 
     Optional<Writing> findByMemberIdAndId(final Long memberId, final Long writingId);
 
-    @Query(value = "select * from Writing as w " +
+    @Query(value = "select * from writing w " +
             "where w.member_id = :memberId and " +
             "w.status = 'TRASHED'", nativeQuery = true)
     List<Writing> findAllByMemberIdAndStatusIsTrashed(@Param("memberId") final Long memberId);
 
-    @Query(value = "select * from Writing as w " +
+    @Query(value = "select * from writing w " +
             "where w.member_id = :memberId and " +
             "w.id = :writingId and " +
             "w.status = 'TRASHED'", nativeQuery = true)
     Optional<Writing> findByMemberIdAndWritingIdAndStatusIsTrashed(final Long memberId, final Long writingId);
 
-    @Query(value = "select * from Writing as w " +
+    @Query(value = "select * from writing w " +
             "where w.member_id = :memberId and " +
             "w.id = :writingId and " +
             "w.status != 'DELETED'", nativeQuery = true)


### PR DESCRIPTION
### 🛠️ Issue

- close #304 

### ✅ Tasks
- JPA 메서드 Query의 `Writing` -> `writing`으로 키워드 변경

### ⏰ Time Difference
- 0