### PR TITLE
[FE] feat: 휴지통에 있는 글을 볼 때 글 제목변경, 발행 안되게 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,7 @@ const App = () => {
         </ErrorBoundary>
         <ToastContainer />
       </ToastProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
+      {PRODUCT_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
     </QueryClientProvider>
   );
 };

--- a/frontend/src/components/FileUploadModal/useFileUploadModal.ts
+++ b/frontend/src/components/FileUploadModal/useFileUploadModal.ts
@@ -28,6 +28,9 @@ export const useFileUploadModal = ({ categoryId, closeModal }: Args) => {
 
   const { mutate: uploadFile, isLoading: isFileUploadLoading } = useMutation(addWriting, {
     onSuccess: (data) => onFileUploadSuccess(data.headers),
+    onError: (error) => {
+      toast.show({ type: 'error', message: getErrorMessage(error) });
+    },
   });
 
   const onFileUploadSuccess = (headers: Headers) => {

--- a/frontend/src/components/TrashCan/DeletedWritingList.tsx
+++ b/frontend/src/components/TrashCan/DeletedWritingList.tsx
@@ -22,7 +22,11 @@ const DeletedWritingList = () => {
           <S.Button
             aria-label={`${deletedWriting.title}글 메인화면에 열기`}
             onClick={() =>
-              goWritingPage({ categoryId: deletedWriting.categoryId, writingId: deletedWriting.id })
+              goWritingPage({
+                categoryId: deletedWriting.categoryId,
+                writingId: deletedWriting.id,
+                isDeletedWriting: true,
+              })
             }
           >
             <S.IconWrapper>

--- a/frontend/src/components/TrashCanTable/TrashCanTable.tsx
+++ b/frontend/src/components/TrashCanTable/TrashCanTable.tsx
@@ -60,7 +60,11 @@ const TrashCanTable = ({ writings }: Props) => {
                   onChange={() => toggleCheckbox(id)}
                 />
               </td>
-              <td onClick={() => goWritingPage({ categoryId, writingId: id })}>{title}</td>
+              <td
+                onClick={() => goWritingPage({ categoryId, writingId: id, isDeletedWriting: true })}
+              >
+                {title}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/WritingSideBar/WritingSideBar.stories.tsx
+++ b/frontend/src/components/WritingSideBar/WritingSideBar.stories.tsx
@@ -5,15 +5,8 @@ import WritingSideBar from './WritingSideBar';
 const meta: Meta<typeof WritingSideBar> = {
   title: 'publishing/WritingSideBar',
   component: WritingSideBar,
-  args: {
-    writingId: 200,
-  },
-  argTypes: {
-    writingId: {
-      description: '글의 id값입니다.',
-      control: { type: 'number' },
-    },
-  },
+  args: {},
+  argTypes: {},
 };
 
 export default meta;

--- a/frontend/src/components/WritingSideBar/WritingSideBar.tsx
+++ b/frontend/src/components/WritingSideBar/WritingSideBar.tsx
@@ -4,7 +4,7 @@ import { css, styled } from 'styled-components';
 import { sidebarStyle } from 'styles/layoutStyle';
 import { useCurrentTab } from './useCurrentTab';
 import { InfoIcon, PublishingIcon } from 'assets/icons';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Blog } from 'types/domain';
 import WritingPropertySection from 'components/WritingPropertySection/WritingPropertySection';
 import Button from 'components/@common/Button/Button';
@@ -22,7 +22,11 @@ const ariaLabelFromTabKeys = {
   [TabKeys.PublishingProperty]: '발행 정보',
 };
 
-const WritingSideBar = () => {
+type Props = {
+  isPublishingSectionActive?: boolean;
+};
+
+const WritingSideBar = ({ isPublishingSectionActive = true }: Props) => {
   const writingId = Number(useParams()['writingId']);
   const { currentTab, selectCurrentTab } = useCurrentTab<TabKeys>(TabKeys.WritingProperty);
   const [publishTo, setPublishTo] = useState<Blog | null>(null);
@@ -37,24 +41,31 @@ const WritingSideBar = () => {
       label: <InfoIcon width={24} height={24} />,
       content: <WritingPropertySection writingId={writingId} />,
     },
-    {
-      key: TabKeys.Publishing,
-      label: <PublishingIcon width={24} height={24} />,
-      content: (
-        <PublishingSection onTabClick={selectCurrentTab} onBlogButtonClick={selectPublishTo} />
-      ),
-    },
-    {
-      key: TabKeys.PublishingProperty,
-      label: 'PublishingProperty',
-      content: publishTo && (
-        <PublishingPropertySection
-          writingId={writingId}
-          publishTo={publishTo}
-          selectCurrentTab={selectCurrentTab}
-        />
-      ),
-    },
+    ...(isPublishingSectionActive
+      ? [
+          {
+            key: TabKeys.Publishing,
+            label: <PublishingIcon width={24} height={24} />,
+            content: (
+              <PublishingSection
+                onTabClick={selectCurrentTab}
+                onBlogButtonClick={selectPublishTo}
+              />
+            ),
+          },
+          {
+            key: TabKeys.PublishingProperty,
+            label: 'PublishingProperty',
+            content: publishTo && (
+              <PublishingPropertySection
+                writingId={writingId}
+                publishTo={publishTo}
+                selectCurrentTab={selectCurrentTab}
+              />
+            ),
+          },
+        ]
+      : []),
   ];
 
   useEffect(() => {

--- a/frontend/src/components/WritingSideBar/WritingSideBar.tsx
+++ b/frontend/src/components/WritingSideBar/WritingSideBar.tsx
@@ -57,6 +57,10 @@ const WritingSideBar = () => {
     },
   ];
 
+  useEffect(() => {
+    selectCurrentTab(TabKeys.WritingProperty);
+  }, [writingId]);
+
   return (
     <S.SidebarContainer>
       <S.MenuTabList role='tablist'>

--- a/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
+++ b/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
@@ -9,9 +9,10 @@ type Props = {
   writingId: number;
   categoryId: number;
   title: string;
+  canEditTitle?: boolean;
 };
 
-const WritingTitle = ({ writingId, categoryId, title }: Props) => {
+const WritingTitle = ({ writingId, categoryId, title, canEditTitle = true }: Props) => {
   const {
     inputRef,
     escapeInput: escapeRename,
@@ -63,9 +64,11 @@ const WritingTitle = ({ writingId, categoryId, title }: Props) => {
           <S.Title ref={myRef} tabIndex={0}>
             {title}
           </S.Title>
-          <S.Button aria-label={'글 제목 수정'} onClick={openInput}>
-            <PencilIcon width={20} height={20} />
-          </S.Button>
+          {canEditTitle && (
+            <S.Button aria-label={'글 제목 수정'} onClick={openInput}>
+              <PencilIcon width={20} height={20} />
+            </S.Button>
+          )}
         </>
       )}
     </S.TitleWrapper>

--- a/frontend/src/components/WritingViewer/WritingViewer.tsx
+++ b/frontend/src/components/WritingViewer/WritingViewer.tsx
@@ -11,9 +11,10 @@ import WritingTitle from './WritingTitle/WritingTitle';
 type Props = {
   writingId: number;
   categoryId: number;
+  isDeletedWriting?: boolean;
 };
 
-const WritingViewer = ({ writingId, categoryId }: Props) => {
+const WritingViewer = ({ writingId, categoryId, isDeletedWriting }: Props) => {
   const { data, isLoading } = useQuery(['writings', writingId], () => getWriting(writingId));
 
   useEffect(() => {
@@ -31,7 +32,12 @@ const WritingViewer = ({ writingId, categoryId }: Props) => {
 
   return (
     <S.WritingViewerContainer>
-      <WritingTitle categoryId={categoryId} writingId={writingId} title={data?.title ?? ''} />
+      <WritingTitle
+        categoryId={categoryId}
+        writingId={writingId}
+        title={data?.title ?? ''}
+        canEditTitle={!isDeletedWriting}
+      />
       <Divider />
       <S.ContentWrapper
         tabIndex={0}

--- a/frontend/src/hooks/usePageNavigate.ts
+++ b/frontend/src/hooks/usePageNavigate.ts
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 export const usePageNavigate = () => {
   const navigate = useNavigate();
 
+  // 여기서 라우터 context 써서 isDeletedWriting set하면 되지 않을까?
   const goIntroducePage = () => navigate(NAVIGATE_PATH.introducePage);
 
   const goSpacePage = () => navigate(NAVIGATE_PATH.spacePage);
@@ -11,8 +12,18 @@ export const usePageNavigate = () => {
   const goWritingTablePage = (categoryId: number) =>
     navigate(NAVIGATE_PATH.getWritingTablePage(categoryId));
 
-  const goWritingPage = ({ categoryId, writingId }: { categoryId: number; writingId: number }) =>
-    navigate(NAVIGATE_PATH.getWritingPage(categoryId, writingId));
+  const goWritingPage = ({
+    categoryId,
+    writingId,
+    isDeletedWriting = false,
+  }: {
+    categoryId: number;
+    writingId: number;
+    isDeletedWriting?: boolean;
+  }) =>
+    navigate(NAVIGATE_PATH.getWritingPage(categoryId, writingId), {
+      state: { isDeletedWriting: isDeletedWriting },
+    });
 
   const goTrashCanPage = () => navigate(NAVIGATE_PATH.trashCanPage);
 

--- a/frontend/src/pages/Layout/Layout.tsx
+++ b/frontend/src/pages/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Outlet, useOutletContext } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { PlusCircleIcon } from 'assets/icons';
@@ -15,15 +15,20 @@ import TrashCan from 'components/TrashCan/TrashCan';
 export type PageContext = {
   isLeftSidebarOpen?: boolean;
   isRightSidebarOpen?: boolean;
-  setActiveWritingId?: Dispatch<SetStateAction<number | null>>;
+  setActiveWritingInfo?: Dispatch<SetStateAction<ActiveWritingInfo | null>>;
+};
+
+type ActiveWritingInfo = {
+  id: number;
+  isDeleted: boolean;
 };
 
 const Layout = () => {
   const [isLeftSidebarOpen, setIsLeftSidebarOpen] = useState(true);
   const [isRightSidebarOpen, setIsRightSidebarOpen] = useState(true);
-  const [activeWritingId, setActiveWritingId] = useState<number | null>(null);
+  const [activeWritingInfo, setActiveWritingInfo] = useState<ActiveWritingInfo | null>(null);
   const { isOpen, openModal, closeModal } = useModal();
-  const isWritingViewerActive = activeWritingId !== null;
+  const isWritingViewerActive = activeWritingInfo !== null;
 
   const toggleLeftSidebar = () => {
     setIsLeftSidebarOpen(!isLeftSidebarOpen);
@@ -64,14 +69,14 @@ const Layout = () => {
               {
                 isLeftSidebarOpen,
                 isRightSidebarOpen,
-                setActiveWritingId,
+                setActiveWritingInfo,
               } satisfies PageContext
             }
           />
         </S.Main>
         {isWritingViewerActive && (
           <S.RightSidebarSection $isRightSidebarOpen={isRightSidebarOpen}>
-            <WritingSideBar />
+            <WritingSideBar isPublishingSectionActive={!activeWritingInfo?.isDeleted} />
           </S.RightSidebarSection>
         )}
       </S.Row>

--- a/frontend/src/pages/MyPage/MyPage.tsx
+++ b/frontend/src/pages/MyPage/MyPage.tsx
@@ -12,6 +12,14 @@ const MyPage = () => {
   const { data, isLoading } = useQuery<MemberResponse>(['member'], getMemberInfo);
   const { goSpacePage } = usePageNavigate();
 
+  if (isLoading)
+    return (
+      <S.SpinnerContainer>
+        <Spinner size={48} thickness={6} />
+        <p>마이 페이지로 이동 중입니다...</p>
+      </S.SpinnerContainer>
+    );
+
   return (
     <S.Section>
       <S.Header>
@@ -75,5 +83,16 @@ const S = {
     width: 70%;
     padding: 4rem;
     font-size: 1.2rem;
+  `,
+
+  SpinnerContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 1.5rem;
+    width: 100vw;
+    height: 100vh;
+    font-size: 1.5rem;
   `,
 };

--- a/frontend/src/pages/WritingPage/WritingPage.tsx
+++ b/frontend/src/pages/WritingPage/WritingPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 import WritingViewer from 'components/WritingViewer/WritingViewer';
 import { usePageContext } from 'pages/Layout/Layout';
@@ -7,17 +7,25 @@ import { useEffect } from 'react';
 const WritingPage = () => {
   const writingId = Number(useParams()['writingId']);
   const categoryId = Number(useParams()['categoryId']);
-  const { setActiveWritingId } = usePageContext();
+  const { setActiveWritingInfo } = usePageContext();
+  const location = useLocation();
+  const isDeletedWriting = location.state.isDeletedWriting;
 
   useEffect(() => {
     const clearActiveWritingId = () => {
-      setActiveWritingId?.(null);
+      setActiveWritingInfo?.(null);
     };
-    setActiveWritingId?.(writingId);
+    setActiveWritingInfo?.({ id: writingId, isDeleted: isDeletedWriting });
     return () => clearActiveWritingId();
-  }, []);
+  }, [isDeletedWriting]);
 
-  return <WritingViewer categoryId={categoryId} writingId={writingId} />;
+  return (
+    <WritingViewer
+      categoryId={categoryId}
+      writingId={writingId}
+      isDeletedWriting={isDeletedWriting}
+    />
+  );
 };
 
 export default WritingPage;


### PR DESCRIPTION
### 🛠️ Issue

- close #328

### ✅ Tasks
- development mode일 때만 ReactQueryDevtools 렌더링 되도록 수정
- 마이페이지 로딩 스피너 위치 중앙으로 이동
- 글 추가 실패 시 에러 토스트 출력
- `WritingViewer`의 글이 바뀌면 `WritingSideBar` 의 `currentTab`을 글 정보로 변경
- 휴지통에 있는 글을 볼 때 글 제목변경, 발행 안되게 수정
  - 글을 보는 페이지로 이동하는 라우팅 로직인 goWritingPage을 할 때, 삭제된 글인지 여부를 location.state로 넣어줍니다. WritingPage에서는 location.state를 꺼내서 글 제목 수정을 막기 위해 WritingViewer에 prop으로 넣어주고, 사이드바 발행탭을 없애기위해 setActiveWritingInfo에 넣어 호출합니다. 
  - 오른쪽 글 정보 사이드바: Layout 에 있는 PageContext의 setActiveWritingId를 setActiveWritingInfo 객체로 수정하여 객체 내부에는 기존 setActiveWritingId와 삭제된 글인지 여부인 isDeleted가 정의됩니다. isDeleted를 WritingSideBar prop으로 넣어서 오른쪽 사이드 바 글 정보 섹션의 조건부 렌더링을 수행합니다.
  - 글 제목 수정: goWritingPage을 할 때 넣어주는 isDeletedWriting(location.state)값을 WritingPage에서 꺼내기 때문에, 바로WritingViewer의 prop으로 isDeletedWriting을 넣어주어 조건부 렌더링을 수행합니다.

### ⏰ Time Difference
- 2 + 2

### 📝 Note
- 
