### PR TITLE
[BE] fix: 영구삭제된 글들도 카테고리를 변경해주도록 메서드 변경

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -34,8 +34,8 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
     @Query(value = "select * from writing w " +
             "where w.member_id = :memberId and " +
             "w.category_id = :categoryId and " +
-            "w.status = 'TRASHED'", nativeQuery = true)
-    List<Writing> findAllByMemberIdAndCategoryIdAndStatusIsTrashed(@Param("memberId") final Long memberId, @Param("categoryId") final Long categoryId);
+            "w.status in ('TRASHED','DELETED')", nativeQuery = true)
+    List<Writing> findAllByMemberIdAndCategoryIdAndStatusIsTrashedAndDeleted(@Param("memberId") final Long memberId, @Param("categoryId") final Long categoryId);
 
     @Query(value = "select * from writing w " +
             "where w.member_id = :memberId and " +

--- a/backend/src/main/java/org/donggle/backend/application/service/CategoryService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/CategoryService.java
@@ -143,9 +143,9 @@ public class CategoryService {
         final Category findCategory = findCategory(findMember.getId(), categoryId);
         validateBasicCategory(memberId, findCategory);
 
-        List<Writing> trashedWritingInCategory = writingRepository.findAllByMemberIdAndCategoryIdAndStatusIsTrashed(memberId, categoryId);
-        Category basicCategory = findBasicCategoryByMemberId(memberId);
-        for (Writing writing : trashedWritingInCategory) {
+        final List<Writing> trashedWritingInCategory = writingRepository.findAllByMemberIdAndCategoryIdAndStatusIsTrashedAndDeleted(memberId, categoryId);
+        final Category basicCategory = findBasicCategoryByMemberId(memberId);
+        for (final Writing writing : trashedWritingInCategory) {
             writing.changeCategory(basicCategory);
         }
 

--- a/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
@@ -122,6 +122,7 @@ class CategoryServiceTest {
         final Category secondCategory = categoryRepository.findById(secondId).get();
         writingRepository.findById(1L).get()
                 .changeCategory(secondCategory);
+        writingRepository.delete(writingRepository.findById(1L).get());
 
         //when
         categoryService.removeCategory(1L, secondId);
@@ -130,7 +131,7 @@ class CategoryServiceTest {
         categoryRepository.flush();
         writingRepository.flush();
 
-        final Writing writing = writingRepository.findById(1L).get();
+        final Writing writing = writingRepository.findAllByMemberIdAndCategoryIdAndStatusIsTrashedAndDeleted(1L, 1L).get(0);
 
         //then
         assertAll(


### PR DESCRIPTION
### 🛠️ Issue

- close #359 

### ✅ Tasks
- 카테고리를 변경할때, 영구삭제된 글들도 카테고리를 기본 카테고리로 변경하도록 수정

### ⏰ Time Difference
- 

### 📝 Note
- 테스트 코드 추가해서 돌아가는 것 확인
- 프로덕션환경에서 수정된 쿼리와 똑같은 쿼리를 실행시켜서 카테고리가 성공적으로 삭제되는 것을 확인
