### PR TITLE
[FE] fix: 글이 있는 카테고리 삭제 시 왼쪽 사이드바에서 글들이 기본 카테고리로 옮겨진 것을 볼 수 없는 버그 수정

### DIFF
--- a/frontend/src/components/Category/useCategoryMutation.ts
+++ b/frontend/src/components/Category/useCategoryMutation.ts
@@ -24,6 +24,7 @@ export const useCategoryMutation = () => {
   const { mutate: deleteCategory } = useMutation(deleteCategoryRequest, {
     onSuccess: () => {
       queryClient.invalidateQueries(['categories']);
+      queryClient.invalidateQueries(['writingsInCategory']);
     },
   });
 


### PR DESCRIPTION
### 🛠️ Issue

- close #360 

### ✅ Tasks
- 카테고리 삭제 시 카테고리 내부 글들을(`writingsInCategory`) invalidate

### ⏰ Time Difference
- 0.1

### 📝 Note
- 
