### PR TITLE
[FE] feat: 회원 탈퇴 기능 구현

### DIFF
--- a/frontend/src/apis/member.ts
+++ b/frontend/src/apis/member.ts
@@ -3,3 +3,6 @@ import { http } from './fetch';
 
 // 멤버페이지 정보 조회: GET
 export const getMemberInfo = () => http.get(memberURL);
+
+// 멤버 탈퇴: POST
+export const deleteMemberAccount = () => http.post(`${memberURL}/delete`);

--- a/frontend/src/components/Modal/DeleteAccountModal.tsx/DeleteAccountModal.tsx
+++ b/frontend/src/components/Modal/DeleteAccountModal.tsx/DeleteAccountModal.tsx
@@ -1,0 +1,79 @@
+import Modal from 'components/@common/Modal/Modal';
+import { styled } from 'styled-components';
+
+type Props = {
+  isOpen: boolean;
+  closeModal: () => void;
+};
+
+const DeleteAccountModal = ({ isOpen, closeModal }: Props) => {
+  return (
+    <Modal isOpen={isOpen} closeModal={closeModal}>
+      <S.Container>
+        <S.Title>회원 탈퇴</S.Title>
+        <S.Content>
+          <p>탈퇴 시, 회원 정보가 모두 삭제되고 재가입 시 복원되지 않습니다.</p>
+          <p>정말 탈퇴하시겠습니까?</p>
+        </S.Content>
+        <S.ButtonContainer>
+          <S.DeleteAccountButton onClick={() => {}}>탈퇴</S.DeleteAccountButton>
+          <S.CancelButton onClick={closeModal}>취소</S.CancelButton>
+        </S.ButtonContainer>
+      </S.Container>
+    </Modal>
+  );
+};
+
+export default DeleteAccountModal;
+
+const S = {
+  Container: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3rem;
+    width: 50vw;
+    max-width: 40rem;
+  `,
+  Title: styled.h1`
+    font-size: 2rem;
+    font-weight: 700;
+  `,
+  Content: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    height: 100%;
+    margin: 2rem 0;
+    font-size: 1.3rem;
+  `,
+  ButtonContainer: styled.div`
+    display: flex;
+    gap: 1rem;
+    button {
+      padding: 1rem 6rem;
+      border-radius: 8px;
+    }
+  `,
+  DeleteAccountButton: styled.button`
+    border: 2px solid ${({ theme }) => theme.color.red5};
+    background-color: ${({ theme }) => theme.color.red5};
+    color: ${({ theme }) => theme.color.gray1};
+
+    &:hover {
+      border: 2px solid ${({ theme }) => theme.color.red6};
+      background-color: ${({ theme }) => theme.color.red6};
+    }
+  `,
+  CancelButton: styled.button`
+    border: 2px solid ${({ theme }) => theme.color.gray4};
+    background-color: ${({ theme }) => theme.color.gray4};
+
+    &:hover {
+      border: 2px solid ${({ theme }) => theme.color.gray5};
+      background-color: ${({ theme }) => theme.color.gray5};
+    }
+  `,
+};

--- a/frontend/src/components/Modal/DeleteAccountModal.tsx/DeleteAccountModal.tsx
+++ b/frontend/src/components/Modal/DeleteAccountModal.tsx/DeleteAccountModal.tsx
@@ -1,4 +1,5 @@
 import Modal from 'components/@common/Modal/Modal';
+import { useMemberDelete } from 'hooks/queries/member/useMemberDelete';
 import { styled } from 'styled-components';
 
 type Props = {
@@ -7,6 +8,12 @@ type Props = {
 };
 
 const DeleteAccountModal = ({ isOpen, closeModal }: Props) => {
+  const deleteMember = useMemberDelete();
+
+  const deleteAccount = () => {
+    deleteMember.mutate();
+  };
+
   return (
     <Modal isOpen={isOpen} closeModal={closeModal}>
       <S.Container>
@@ -16,7 +23,7 @@ const DeleteAccountModal = ({ isOpen, closeModal }: Props) => {
           <p>정말 탈퇴하시겠습니까?</p>
         </S.Content>
         <S.ButtonContainer>
-          <S.DeleteAccountButton onClick={() => {}}>탈퇴</S.DeleteAccountButton>
+          <S.DeleteAccountButton onClick={deleteAccount}>탈퇴</S.DeleteAccountButton>
           <S.CancelButton onClick={closeModal}>취소</S.CancelButton>
         </S.ButtonContainer>
       </S.Container>

--- a/frontend/src/components/Profile/Profile.tsx
+++ b/frontend/src/components/Profile/Profile.tsx
@@ -1,4 +1,6 @@
 import { DefaultUserProfileIcon } from 'assets/icons';
+import DeleteAccountModal from 'components/Modal/DeleteAccountModal.tsx/DeleteAccountModal';
+import { useModal } from 'hooks/@common/useModal';
 import { styled } from 'styled-components';
 
 type Props = {
@@ -6,11 +8,17 @@ type Props = {
 };
 
 const Profile = ({ name }: Props) => {
+  const { isOpen, openModal, closeModal } = useModal();
+
   return (
-    <S.Profile>
-      <DefaultUserProfileIcon />
-      {name}
-    </S.Profile>
+    <>
+      <S.Profile>
+        <DefaultUserProfileIcon />
+        {name}
+        <S.DeleteAccountButton onClick={openModal}>탈퇴하기</S.DeleteAccountButton>
+      </S.Profile>
+      <DeleteAccountModal isOpen={isOpen} closeModal={closeModal} />
+    </>
   );
 };
 
@@ -29,5 +37,15 @@ const S = {
     background-color: ${({ theme }) => theme.color.gray2};
     font-size: 2rem;
     font-weight: bold;
+  `,
+  DeleteAccountButton: styled.button`
+    padding: 0.1rem 0;
+    color: ${({ theme }) => theme.color.gray7};
+    border-bottom: 1px solid ${({ theme }) => theme.color.gray6};
+
+    &:hover {
+      color: ${({ theme }) => theme.color.gray8};
+      border-bottom: 1px solid ${({ theme }) => theme.color.gray7};
+    }
   `,
 };

--- a/frontend/src/hooks/queries/member/useMemberDelete.ts
+++ b/frontend/src/hooks/queries/member/useMemberDelete.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { deleteMemberAccount } from 'apis/member';
+import { useToast } from 'hooks/@common/useToast';
+import { usePageNavigate } from 'hooks/usePageNavigate';
+import { getErrorMessage } from 'utils/error';
+
+export const useMemberDelete = () => {
+  const toast = useToast();
+  const { goIntroducePage } = usePageNavigate();
+
+  return useMutation(deleteMemberAccount, {
+    onSuccess: () => {
+      localStorage.removeItem('accessToken');
+      goIntroducePage();
+      toast.show({ type: 'success', message: '탈퇴가 완료되었습니다.' });
+    },
+    onError: (error) => {
+      toast.show({ type: 'error', message: getErrorMessage(error) });
+    },
+  });
+};

--- a/frontend/src/mocks/handlers/member.ts
+++ b/frontend/src/mocks/handlers/member.ts
@@ -6,4 +6,9 @@ export const memberHandlers = [
   rest.get(memberURL, (_, res, ctx) => {
     return res(ctx.json(member), ctx.status(200));
   }),
+
+  // 회원 탈퇴: POST
+  rest.post(`${memberURL}/delete`, (_, res, ctx) => {
+    return res(ctx.status(200));
+  }),
 ];


### PR DESCRIPTION
### 🛠️ Issue

- close #388

### ✅ Tasks
- [x] 회원 탈퇴 UI 구현
- [x] 회원 탈퇴 API mocking
- [x] 회원 탈퇴 API 연결

### ⏰ Time Difference
- 0.5 -> 2

### 📝 Note
- 탈퇴 시 한번 더 확인할 수 있는 모달을 추가했습니다.
- 탈퇴 완료 시 accessToken을 지우고 introduce 페이지로 리다이렉트 시켰습니다.
