### PR TITLE
[BE] feat: 회원 탈퇴 기능 구현

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
@@ -29,6 +29,7 @@ public class MemberService {
 
     public void deleteMember(final Long memberId) {
         final Member findMember = findMember(memberId);
+        findMember.updateDeletedAt();
         memberRepository.delete(findMember);
     }
 

--- a/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
@@ -21,16 +21,15 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberPageResponse findMemberPage(final Long memberId) {
-        final Member findMember = findMember(memberId);
-        final MemberCredentials foundMemberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(findMember)
+        final Member member = findMember(memberId);
+        final MemberCredentials memberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(member)
                 .orElseThrow(NoSuchElementException::new);
-        return MemberPageResponse.of(findMember, foundMemberCredentials);
+        return MemberPageResponse.of(member, memberCredentials);
     }
 
     public void deleteMember(final Long memberId) {
-        final Member findMember = findMember(memberId);
-        findMember.updateDeletedAt();
-        memberRepository.delete(findMember);
+        final Member member = findMember(memberId);
+        memberRepository.delete(member);
     }
 
     private Member findMember(final Long memberId) {

--- a/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/MemberService.java
@@ -21,10 +21,19 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberPageResponse findMemberPage(final Long memberId) {
-        final Member foundMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
-        final MemberCredentials foundMemberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(foundMember)
+        final Member findMember = findMember(memberId);
+        final MemberCredentials foundMemberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(findMember)
                 .orElseThrow(NoSuchElementException::new);
-        return MemberPageResponse.of(foundMember, foundMemberCredentials);
+        return MemberPageResponse.of(findMember, foundMemberCredentials);
+    }
+
+    public void deleteMember(final Long memberId) {
+        final Member findMember = findMember(memberId);
+        memberRepository.delete(findMember);
+    }
+
+    private Member findMember(final Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
     }
 }

--- a/backend/src/main/java/org/donggle/backend/domain/member/Member.java
+++ b/backend/src/main/java/org/donggle/backend/domain/member/Member.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE member SET is_deleted = true, deleted_at = now() WHERE id = ?")
 @Where(clause = "is_deleted = false")
 @Table(uniqueConstraints = @UniqueConstraint(name = "SOCIAL_ID_UNIQUE", columnNames = "socialId"))
 public class Member extends BaseEntity {
@@ -42,10 +42,6 @@ public class Member extends BaseEntity {
 
     public static Member of(final MemberName memberName, final Long socialId) {
         return new Member(memberName, socialId);
-    }
-
-    public void updateDeletedAt() {
-        this.deletedAt = LocalDateTime.now();
     }
 
     @Override

--- a/backend/src/main/java/org/donggle/backend/domain/member/Member.java
+++ b/backend/src/main/java/org/donggle/backend/domain/member/Member.java
@@ -15,6 +15,7 @@ import org.donggle.backend.domain.BaseEntity;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
@@ -31,7 +32,8 @@ public class Member extends BaseEntity {
     @Embedded
     private MemberName memberName;
     private Long socialId;
-    boolean isDeleted = false;
+    private boolean isDeleted = false;
+    private LocalDateTime deletedAt;
 
     private Member(final MemberName memberName, final Long socialId) {
         this.memberName = memberName;
@@ -40,6 +42,10 @@ public class Member extends BaseEntity {
 
     public static Member of(final MemberName memberName, final Long socialId) {
         return new Member(memberName, socialId);
+    }
+
+    public void updateDeletedAt() {
+        this.deletedAt = LocalDateTime.now();
     }
 
     @Override

--- a/backend/src/main/java/org/donggle/backend/domain/member/Member.java
+++ b/backend/src/main/java/org/donggle/backend/domain/member/Member.java
@@ -12,12 +12,16 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.donggle.backend.domain.BaseEntity;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.Objects;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 @Table(uniqueConstraints = @UniqueConstraint(name = "SOCIAL_ID_UNIQUE", columnNames = "socialId"))
 public class Member extends BaseEntity {
     @Id
@@ -27,6 +31,7 @@ public class Member extends BaseEntity {
     @Embedded
     private MemberName memberName;
     private Long socialId;
+    boolean isDeleted = false;
 
     private Member(final MemberName memberName, final Long socialId) {
         this.memberName = memberName;

--- a/backend/src/main/java/org/donggle/backend/ui/MemberController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/MemberController.java
@@ -6,6 +6,7 @@ import org.donggle.backend.ui.common.AuthenticationPrincipal;
 import org.donggle.backend.ui.response.MemberPageResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +20,11 @@ public class MemberController {
     public ResponseEntity<MemberPageResponse> memberPage(@AuthenticationPrincipal final Long memberId) {
         final MemberPageResponse memberPage = memberService.findMemberPage(memberId);
         return ResponseEntity.ok(memberPage);
+    }
+
+    @PostMapping("/delete")
+    public ResponseEntity<Void> deleteMember(@AuthenticationPrincipal final Long memberId) {
+        memberService.deleteMember(memberId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/test/java/org/donggle/backend/application/service/MemberServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/MemberServiceTest.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -64,5 +66,21 @@ class MemberServiceTest {
                 () -> assertThat(memberPage.notion().isConnected()).isFalse(),
                 () -> assertThat(memberPage.medium().isConnected()).isTrue()
         );
+    }
+
+    @Test
+    @DisplayName("회원을 탈퇴한다.")
+    void deleteMember() {
+        //given
+        final Member member = memberRepository.save(Member.of(new MemberName("동굴"), 123L));
+        assertThat(member.isDeleted()).isFalse();
+
+        //when
+        memberService.deleteMember(member.getId());
+        memberRepository.flush();
+
+        //then
+        final Optional<Member> memberOptional = memberRepository.findById(member.getId());
+        assertThat(memberOptional).isEmpty();
     }
 }


### PR DESCRIPTION
### 🛠️ Issue

- close #407 

### ✅ Tasks
- 회원 탈퇴 컬럼 추가
- 소프트 딜리트 구현
- 스케줄 작동 테스트
- 해당 회원의 정보 삭제 로직 구현

### ⏰ Time Difference
- 3

### 📝 Note
애플리케이션 상에서 회원 탈퇴는 소프트 딜리트로 구현하였습니다. 이를 위해 isDeleted와 deletedAt 컬럼을 추가하였고, 실제 데이터베이스에서 회원 정보를 삭제하는 것은 ec2에서 crontab 스케줄러를 사용하여 구현하였습니다. 매일 새벽 3시에 데이터베이스에서 탈퇴한지 30일이 지난 사용자들의 정보를 삭제해주도록 설정하였습니다. 이에 대한 자세한 내용은 블로그에 작성하겠습니다.

스프링 애플리케이션이 아닌 ec2에서 직접 스케줄러와 sql 스크립트를 작동시킨 이유는, 굳이 애플리케이션의 연산 자원을 사용하기보다 많은 데이터를 한 번에 처리하는 것은 독립적인 스크립트로 작성하는 것이 좋다고 판단했기 때문입니다. 
