### PR TITLE
[BE] feat: 복합 유니크 인덱스를 이용한 사용자의 중복실행(글,카테고리 추가) 막기

### DIFF
--- a/backend/src/main/java/org/donggle/backend/config/InitLocalAndTestData.java
+++ b/backend/src/main/java/org/donggle/backend/config/InitLocalAndTestData.java
@@ -6,6 +6,7 @@ import org.donggle.backend.application.repository.CategoryRepository;
 import org.donggle.backend.application.repository.MemberCredentialsRepository;
 import org.donggle.backend.application.repository.MemberRepository;
 import org.donggle.backend.application.repository.WritingRepository;
+import org.donggle.backend.domain.OrderStatus;
 import org.donggle.backend.domain.blog.Blog;
 import org.donggle.backend.domain.blog.BlogType;
 import org.donggle.backend.domain.category.Category;
@@ -60,7 +61,7 @@ public class InitLocalAndTestData implements CommandLineRunner {
             blogRepository.save(new Blog(BlogType.MEDIUM));
             blogRepository.save(new Blog(BlogType.TISTORY));
 
-            writingRepository.save(Writing.of(
+            final Writing savedWriting = writingRepository.save(Writing.of(
                     savedMember,
                     new Title("테스트 글"),
                     savedCategory,
@@ -74,6 +75,7 @@ public class InitLocalAndTestData implements CommandLineRunner {
                             )
                     )
             ));
+            savedWriting.changeNextWritingId(OrderStatus.END.getStatusValue());
         }
     }
 }

--- a/backend/src/main/java/org/donggle/backend/domain/OrderStatus.java
+++ b/backend/src/main/java/org/donggle/backend/domain/OrderStatus.java
@@ -1,0 +1,16 @@
+package org.donggle.backend.domain;
+
+public enum OrderStatus {
+    END(-1L),
+    DISCONNECTION(-2L);
+
+    private final Long statusValue;
+
+    OrderStatus(final Long statusValue) {
+        this.statusValue = statusValue;
+    }
+
+    public Long getStatusValue() {
+        return statusValue;
+    }
+}

--- a/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
@@ -119,27 +119,16 @@ class CategoryServiceTest {
     void removeCategory() {
         //given
         final Long secondId = categoryService.addCategory(1L, new CategoryAddRequest("두 번째 카테고리"));
-        final Category secondCategory = categoryRepository.findById(secondId).get();
-        writingRepository.findById(1L).get()
-                .changeCategory(secondCategory);
-        writingRepository.delete(writingRepository.findById(1L).get());
 
         //when
         categoryService.removeCategory(1L, secondId);
         final List<Category> categories = categoryRepository.findAllByMemberId(1L);
 
-        categoryRepository.flush();
-        writingRepository.flush();
-
-        final Writing writing = writingRepository.findAllByMemberIdAndCategoryIdAndStatusIsTrashedAndDeleted(1L, 1L).get(0);
-
         //then
         assertAll(
                 () -> assertThat(categories).hasSize(1),
                 () -> assertThat(categories.get(0).getCategoryName()).isEqualTo(new CategoryName("기본")),
-                () -> assertThat(categories.get(0).getNextCategory()).isNull(),
-                () -> assertThat(writing.getCategory()).isEqualTo(categories.get(0)),
-                () -> assertThat(writing.getNextWriting()).isNull()
+                () -> assertThat(categories.get(0).getNextCategory()).isNull()
         );
     }
 


### PR DESCRIPTION
### 🛠️ Issue

- close #414 

### ✅ Tasks
- Writing 테이블에 categoryId와 nextId를 한번에 복합 유니크 인덱스 생성
- Category 테이블에 memberId와 nextId를 한번에 복합 유니크 인덱스 생성
- 자기 참조하고 있는 Writing의 필드를 next Writing의 Id를 갖고있도록 로직 수정
- 자기 참조하고 있는 Category의 필드를 next Category의 Id를 갖고있도록 로직 수정

### ⏰ Time Difference
- 3