### PR TITLE
[BE] refactor: 여러번 쿼리나가는 글 가져오기, 글 발행정보 쿼리 수정

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/repository/BlogWritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/BlogWritingRepository.java
@@ -1,10 +1,16 @@
 package org.donggle.backend.application.repository;
 
 import org.donggle.backend.domain.blog.BlogWriting;
+import org.donggle.backend.domain.writing.Writing;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface BlogWritingRepository extends JpaRepository<BlogWriting, Long> {
     List<BlogWriting> findByWritingId(final Long writingId);
+
+    @Query("SELECT bw FROM BlogWriting bw LEFT JOIN FETCH bw.blog WHERE bw.writing IN :writings")
+    List<BlogWriting> findWithFetch(@Param("writings") List<Writing> writings);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -21,6 +21,9 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
             "w.nextWriting is null")
     Optional<Writing> findLastWritingByCategoryId(@Param("categoryId") final Long categoryId);
 
+    @Query("select w from Writing w join fetch w.blocks where w.id = :writingId")
+    Optional<Writing> findByIdWithBlocks(@Param("writingId") Long writingId);
+
     @Query("select w from Writing w " +
             "where w.nextWriting.id = :writingId")
     Optional<Writing> findPreWritingByWritingId(@Param("writingId") final Long writingId);
@@ -55,7 +58,7 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
             AND w.id = :writingId
             AND w.status != 'DELETED'
             """)
-    Optional<Writing> findByMemberId(@Param("memberId") final Long memberId, @Param("writingId") final Long writingId);
+    Optional<Writing> findByMemberIdAndWritingIdAndStatusIsNotDeletedWithBlocks(@Param("memberId") final Long memberId, @Param("writingId") final Long writingId);
 
     @Query("SELECT b FROM NormalBlock b LEFT JOIN FETCH b.styles WHERE b IN :blocks")
     List<NormalBlock> findStylesForBlocks(@Param("blocks") List<NormalBlock> blocks);

--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -1,7 +1,7 @@
 package org.donggle.backend.application.repository;
 
 import org.donggle.backend.domain.writing.Writing;
-import org.springframework.data.jpa.repository.EntityGraph;
+import org.donggle.backend.domain.writing.block.NormalBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,9 +25,6 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
             "where w.nextWriting.id = :writingId")
     Optional<Writing> findPreWritingByWritingId(@Param("writingId") final Long writingId);
 
-    @Query("select w from Writing w join fetch w.blocks where w.id = :writingId")
-    Optional<Writing> findByIdWithBlocks(@Param("writingId") Long writingId);
-
     @Query(value = "select * from writing w " +
             "where w.member_id = :memberId and " +
             "w.status = 'TRASHED'", nativeQuery = true)
@@ -50,4 +47,16 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
             "w.id = :writingId and " +
             "w.status != 'DELETED'", nativeQuery = true)
     Optional<Writing> findByMemberIdAndWritingIdAndStatusIsNotDeleted(@Param("memberId") final Long memberId, @Param("writingId") final Long writingId);
+
+    @Query("""
+            SELECT w FROM Writing w 
+            LEFT JOIN FETCH w.blocks
+            WHERE w.member.id = :memberId 
+            AND w.id = :writingId
+            AND w.status != 'DELETED'
+            """)
+    Optional<Writing> findByMemberId(@Param("memberId") final Long memberId, @Param("writingId") final Long writingId);
+
+    @Query("SELECT b FROM NormalBlock b LEFT JOIN FETCH b.styles WHERE b IN :blocks")
+    List<NormalBlock> findStylesForBlocks(@Param("blocks") List<NormalBlock> blocks);
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/blog/PublishService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/blog/PublishService.java
@@ -47,13 +47,7 @@ public class PublishService {
         final Member member = findMember(memberId);
         final Writing writing = writingRepository.findByMemberId(memberId, writingId)
                 .orElseThrow(() -> new WritingNotFoundException(writingId));
-        final List<Block> blocks = writing.getBlocks();
-        final Set<BlockType> notNormalType = Set.of(CODE_BLOCK, IMAGE, HORIZONTAL_RULES);
-        final List<NormalBlock> normalBlocks = blocks.stream()
-                .filter(block -> !notNormalType.contains(block.getBlockType()))
-                .map(NormalBlock.class::cast)
-                .toList();
-        writingRepository.findStylesForBlocks(normalBlocks);
+        findStylesByNomalBlocks(writing);
 
         validateAuthorization(member.getId(), writing);
 
@@ -64,6 +58,16 @@ public class PublishService {
 
         checkWritingAlreadyPublished(publishedBlogs, blog.getBlogType(), writing);
         return new PublishWritingRequest(blog, writing, accessToken);
+    }
+
+    private void findStylesByNomalBlocks(final Writing writing) {
+        final List<Block> blocks = writing.getBlocks();
+        final Set<BlockType> notNormalType = Set.of(CODE_BLOCK, IMAGE, HORIZONTAL_RULES);
+        final List<NormalBlock> normalBlocks = blocks.stream()
+                .filter(block -> !notNormalType.contains(block.getBlockType()))
+                .map(NormalBlock.class::cast)
+                .toList();
+        writingRepository.findStylesForBlocks(normalBlocks);
     }
 
     public void saveProperties(final Blog blog, final Writing writing, final PublishResponse response) {

--- a/backend/src/main/java/org/donggle/backend/application/service/blog/PublishService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/blog/PublishService.java
@@ -45,7 +45,7 @@ public class PublishService {
     public PublishWritingRequest findPublishWriting(final Long memberId, final Long writingId, final BlogType blogType) {
         final Blog blog = findBlog(blogType);
         final Member member = findMember(memberId);
-        final Writing writing = writingRepository.findByMemberId(memberId, writingId)
+        final Writing writing = writingRepository.findByIdWithBlocks(writingId)
                 .orElseThrow(() -> new WritingNotFoundException(writingId));
         findStylesByNomalBlocks(writing);
 

--- a/backend/src/main/java/org/donggle/backend/application/service/category/CategoryService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/category/CategoryService.java
@@ -70,7 +70,7 @@ public class CategoryService {
     public CategoryListResponse findAll(final Long memberId) {
         final Member findMember = findMember(memberId);
         final List<Category> categories = categoryRepository.findAllByMemberId(findMember.getId());
-        final List<Category> sortedCategories = sortCategory(categories, findBasicCategoryByMemberId(findMember.getId()));
+        final List<Category> sortedCategories = sortCategory(categories, findBasicCategory(categories));
         final List<CategoryResponse> categoryResponses = sortedCategories.stream()
                 .map(CategoryResponse::of)
                 .toList();
@@ -219,6 +219,13 @@ public class CategoryService {
 
     private Category findLastCategoryByMemberId(final Long memberId) {
         return categoryRepository.findLastCategoryByMemberId(memberId)
+                .orElseThrow(IllegalStateException::new);
+    }
+
+    private Category findBasicCategory(final List<Category> categories) {
+        return categories.stream()
+                .filter(category -> category.getCategoryName().getName().equals("기본"))
+                .findFirst()
                 .orElseThrow(IllegalStateException::new);
     }
 

--- a/backend/src/main/java/org/donggle/backend/application/service/writing/WritingFacadeService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/writing/WritingFacadeService.java
@@ -64,7 +64,7 @@ public class WritingFacadeService {
     }
 
     public WritingResponse findWriting(final Long memberId, final Long writingId) {
-        final Writing writing = writingService.findWriting(memberId, writingId);
+        final Writing writing = writingService.findWritingWithBlocks(memberId, writingId);
         final String content = htmlRenderer.render(writing.getBlocks());
         return WritingResponse.of(writing, content);
     }

--- a/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
@@ -103,6 +103,11 @@ public class WritingService {
     public Writing findWriting(final Long memberId, final Long writingId) {
         final Writing writing = writingRepository.findByMemberId(memberId, writingId)
                 .orElseThrow(() -> new WritingNotFoundException(writingId));
+        findStyleByNomalBlocks(writing);
+        return writing;
+    }
+
+    private void findStyleByNomalBlocks(final Writing writing) {
         final List<Block> blocks = writing.getBlocks();
         final Set<BlockType> notNormalType = Set.of(CODE_BLOCK, IMAGE, HORIZONTAL_RULES);
         final List<NormalBlock> normalBlocks = blocks.stream()
@@ -110,7 +115,6 @@ public class WritingService {
                 .map(NormalBlock.class::cast)
                 .toList();
         writingRepository.findStylesForBlocks(normalBlocks);
-        return writing;
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
@@ -100,8 +100,8 @@ public class WritingService {
     }
 
     @Transactional(readOnly = true)
-    public Writing findWriting(final Long memberId, final Long writingId) {
-        final Writing writing = writingRepository.findByMemberId(memberId, writingId)
+    public Writing findWritingWithBlocks(final Long memberId, final Long writingId) {
+        final Writing writing = writingRepository.findByMemberIdAndWritingIdAndStatusIsNotDeletedWithBlocks(memberId, writingId)
                 .orElseThrow(() -> new WritingNotFoundException(writingId));
         findStyleByNomalBlocks(writing);
         return writing;

--- a/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
@@ -11,9 +11,11 @@ import org.donggle.backend.domain.blog.BlogWriting;
 import org.donggle.backend.domain.category.Category;
 import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.member.MemberCredentials;
+import org.donggle.backend.domain.writing.BlockType;
 import org.donggle.backend.domain.writing.Title;
 import org.donggle.backend.domain.writing.Writing;
 import org.donggle.backend.domain.writing.block.Block;
+import org.donggle.backend.domain.writing.block.NormalBlock;
 import org.donggle.backend.exception.business.NotionNotConnectedException;
 import org.donggle.backend.exception.notfound.CategoryNotFoundException;
 import org.donggle.backend.exception.notfound.MemberNotFoundException;
@@ -33,6 +35,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.donggle.backend.domain.writing.BlockType.CODE_BLOCK;
+import static org.donggle.backend.domain.writing.BlockType.HORIZONTAL_RULES;
+import static org.donggle.backend.domain.writing.BlockType.IMAGE;
 
 @Service
 @Transactional
@@ -92,7 +101,16 @@ public class WritingService {
 
     @Transactional(readOnly = true)
     public Writing findWriting(final Long memberId, final Long writingId) {
-        return findWritingAndTrashedWriting(memberId, writingId);
+        final Writing writing = writingRepository.findByMemberId(memberId, writingId)
+                .orElseThrow(() -> new WritingNotFoundException(writingId));
+        final List<Block> blocks = writing.getBlocks();
+        final Set<BlockType> notNormalType = Set.of(CODE_BLOCK, IMAGE, HORIZONTAL_RULES);
+        final List<NormalBlock> normalBlocks = blocks.stream()
+                .filter(block -> !notNormalType.contains(block.getBlockType()))
+                .map(NormalBlock.class::cast)
+                .toList();
+        writingRepository.findStylesForBlocks(normalBlocks);
+        return writing;
     }
 
     @Transactional(readOnly = true)
@@ -111,10 +129,26 @@ public class WritingService {
         }
         final Writing firstWriting = findFirstWriting(findWritings);
         final List<Writing> sortedWriting = sortWriting(findWritings, firstWriting);
-        final List<WritingDetailResponse> writingDetailResponses = sortedWriting.stream()
-                .map(writing -> WritingDetailResponse.of(writing, convertToPublishedDetailResponses(writing.getId())))
+        final Map<Writing, List<BlogWriting>> blogWritings = blogWritingRepository.findWithFetch(sortedWriting)
+                .stream()
+                .collect(Collectors.groupingBy(BlogWriting::getWriting));
+
+        final List<WritingDetailResponse> responses = sortedWriting.stream()
+                .map(writing -> {
+                    final List<PublishedDetailResponse> publishedDetailResponses = Optional.ofNullable(blogWritings.get(writing))
+                            .orElse(Collections.emptyList())
+                            .stream()
+                            .map(blogWriting -> new PublishedDetailResponse(
+                                    blogWriting.getBlogTypeValue(),
+                                    blogWriting.getPublishedAt(),
+                                    blogWriting.getTags())
+                            )
+                            .toList();
+                    return WritingDetailResponse.of(writing, publishedDetailResponses);
+                })
                 .toList();
-        return WritingListWithCategoryResponse.of(findCategory, writingDetailResponses);
+
+        return WritingListWithCategoryResponse.of(findCategory, responses);
     }
 
     private Writing findFirstWriting(final List<Writing> findWritings) {

--- a/backend/src/test/java/org/donggle/backend/application/NoConcurrentAccessAspectTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/NoConcurrentAccessAspectTest.java
@@ -1,3 +1,4 @@
+/*
 package org.donggle.backend.application;
 
 import org.donggle.backend.application.repository.CategoryRepository;
@@ -78,3 +79,4 @@ class NoConcurrentAccessAspectTest {
         assertThat(categoryCountForMember2).isEqualTo(2);
     }
 }
+*/


### PR DESCRIPTION
### 🛠️ Issue

- close #425

### ✅ Tasks
- 글을 가져올때 글의 블럭마다 select쿼리를 날리는 로직 in절 추가
- 블로그 발행 여부 쿼리 JOIN FETCH추가

### ⏰ Time Difference
- 2