### PR TITLE
[BE] feat: 미디움, 티스토리 발행 시 선택 정보 추가 기능 구현

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/client/BlogClient.java
+++ b/backend/src/main/java/org/donggle/backend/application/client/BlogClient.java
@@ -1,13 +1,12 @@
 package org.donggle.backend.application.client;
 
+import org.donggle.backend.application.service.request.PublishRequest;
 import org.donggle.backend.domain.blog.BlogType;
 import org.donggle.backend.ui.response.PublishResponse;
 
-import java.util.List;
-
 public interface BlogClient {
 
-    PublishResponse publish(String accessToken, String content, List<String> tags, final String titleValue);
+    PublishResponse publish(String accessToken, String content, PublishRequest publishRequest, final String titleValue);
 
     BlogType getBlogType();
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/blog/PublishFacadeService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/blog/PublishFacadeService.java
@@ -10,8 +10,6 @@ import org.donggle.backend.domain.writing.Writing;
 import org.donggle.backend.ui.response.PublishResponse;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class PublishFacadeService {
@@ -19,17 +17,14 @@ public class PublishFacadeService {
     private final HtmlRenderer htmlRenderer;
     private final BlogClients blogClients;
 
-    public void publishWriting(final Long memberId, final Long writingId, final PublishRequest publishRequest) {
-        final BlogType blogType = BlogType.from(publishRequest.publishTo());
-        final List<String> tags = publishRequest.tags();
-
+    public void publishWriting(final Long memberId, final Long writingId, final BlogType blogType, final PublishRequest publishRequest) {
         final PublishWritingRequest request = publishService.findPublishWriting(memberId, writingId, blogType);
         final Blog blog = request.blog();
         final Writing writing = request.writing();
 
         final String content = htmlRenderer.render(writing.getBlocks());
 
-        final PublishResponse response = blogClients.publish(blogType, tags, content, request.accessToken(), writing.getTitleValue());
+        final PublishResponse response = blogClients.publish(blogType, publishRequest, content, request.accessToken(), writing.getTitleValue());
         publishService.saveProperties(blog, writing, response);
     }
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/request/PublishRequest.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/request/PublishRequest.java
@@ -9,7 +9,7 @@ public record PublishRequest(
         List<String> tags,
         String publishStatus,
         String password,
-        Long categoryId,
+        String categoryId,
         String publishTime
 ) {
     public static PublishRequest tistory(final PublishRequest publishRequest) {

--- a/backend/src/main/java/org/donggle/backend/application/service/request/PublishRequest.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/request/PublishRequest.java
@@ -1,12 +1,46 @@
 package org.donggle.backend.application.service.request;
 
-import jakarta.validation.constraints.NotNull;
+import org.donggle.backend.domain.blog.PublishStatus;
 
 import java.util.List;
+import java.util.Objects;
 
 public record PublishRequest(
-        @NotNull(message = "블로그를 선택해주세요.")
-        String publishTo,
-        List<String> tags
+        List<String> tags,
+        String publishStatus,
+        String password,
+        Long categoryId,
+        String publishTime
 ) {
+    public static PublishRequest tistory(final PublishRequest publishRequest) {
+        final PublishStatus status = PublishStatus.from(publishRequest.publishStatus);
+        if (status == PublishStatus.PUBLIC && !publishRequest.password().isBlank()) {
+            throw new IllegalArgumentException("공개글은 비밀번호를 입력할 수 없습니다.");
+        }
+        if (status == PublishStatus.PRIVATE) {
+            if (!publishRequest.publishTime.isBlank()) {
+                throw new IllegalArgumentException("비밀글은 예약 시간을 정할 수 없습니다.");
+            }
+            if (!publishRequest.password().isBlank()) {
+                throw new IllegalArgumentException("비밀글은 비밀번호를 입력할 수 없습니다.");
+            }
+        }
+        if (status == PublishStatus.PROTECT && publishRequest.password().isBlank()) {
+            throw new IllegalArgumentException("보호글은 비밀번호가 입력되어야 합니다.");
+        }
+        return publishRequest;
+    }
+
+    public static PublishRequest medium(final PublishRequest publishRequest) {
+        if (Objects.nonNull(publishRequest.password())) {
+            throw new IllegalArgumentException("미디움은 비밀번호를 입력할 수 없습니다.");
+        }
+        if (Objects.nonNull(publishRequest.categoryId())) {
+            throw new IllegalArgumentException("미디움은 카테고리를 선택할 수 없습니다.");
+        }
+        if (Objects.nonNull(publishRequest.publishTime())) {
+            throw new IllegalArgumentException("미디움은 예약 시간을 선택할 수 없습니다.");
+        }
+        return publishRequest;
+    }
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/request/PublishRequest.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/request/PublishRequest.java
@@ -1,6 +1,7 @@
 package org.donggle.backend.application.service.request;
 
 import org.donggle.backend.domain.blog.PublishStatus;
+import org.donggle.backend.exception.business.InvalidPublishRequestException;
 
 import java.util.List;
 import java.util.Objects;
@@ -15,31 +16,31 @@ public record PublishRequest(
     public static PublishRequest tistory(final PublishRequest publishRequest) {
         final PublishStatus status = PublishStatus.from(publishRequest.publishStatus);
         if (status == PublishStatus.PUBLIC && !publishRequest.password().isBlank()) {
-            throw new IllegalArgumentException("공개글은 비밀번호를 입력할 수 없습니다.");
+            throw new InvalidPublishRequestException("공개글은 비밀번호를 입력할 수 없습니다.");
         }
         if (status == PublishStatus.PRIVATE) {
             if (!publishRequest.publishTime.isBlank()) {
-                throw new IllegalArgumentException("비밀글은 예약 시간을 정할 수 없습니다.");
+                throw new InvalidPublishRequestException("비밀글은 예약 시간을 정할 수 없습니다.");
             }
             if (!publishRequest.password().isBlank()) {
-                throw new IllegalArgumentException("비밀글은 비밀번호를 입력할 수 없습니다.");
+                throw new InvalidPublishRequestException("비밀글은 비밀번호를 입력할 수 없습니다.");
             }
         }
         if (status == PublishStatus.PROTECT && publishRequest.password().isBlank()) {
-            throw new IllegalArgumentException("보호글은 비밀번호가 입력되어야 합니다.");
+            throw new InvalidPublishRequestException("보호글은 비밀번호가 입력되어야 합니다.");
         }
         return publishRequest;
     }
 
     public static PublishRequest medium(final PublishRequest publishRequest) {
         if (Objects.nonNull(publishRequest.password())) {
-            throw new IllegalArgumentException("미디움은 비밀번호를 입력할 수 없습니다.");
+            throw new InvalidPublishRequestException("미디움은 비밀번호를 입력할 수 없습니다.");
         }
         if (Objects.nonNull(publishRequest.categoryId())) {
-            throw new IllegalArgumentException("미디움은 카테고리를 선택할 수 없습니다.");
+            throw new InvalidPublishRequestException("미디움은 카테고리를 선택할 수 없습니다.");
         }
         if (Objects.nonNull(publishRequest.publishTime())) {
-            throw new IllegalArgumentException("미디움은 예약 시간을 선택할 수 없습니다.");
+            throw new InvalidPublishRequestException("미디움은 예약 시간을 선택할 수 없습니다.");
         }
         return publishRequest;
     }

--- a/backend/src/main/java/org/donggle/backend/domain/blog/BlogClients.java
+++ b/backend/src/main/java/org/donggle/backend/domain/blog/BlogClients.java
@@ -1,10 +1,10 @@
 package org.donggle.backend.domain.blog;
 
 import org.donggle.backend.application.client.BlogClient;
+import org.donggle.backend.application.service.request.PublishRequest;
 import org.donggle.backend.ui.response.PublishResponse;
 
 import java.util.EnumMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -20,13 +20,13 @@ public class BlogClients {
 
     public PublishResponse publish(
             final BlogType blogType,
-            final List<String> tags,
+            final PublishRequest publishRequest,
             final String content,
             final String accessToken,
             final String titleValue
     ) {
         final BlogClient client = getClient(blogType);
-        return client.publish(accessToken, content, tags, titleValue);
+        return client.publish(accessToken, content, publishRequest, titleValue);
     }
 
     private BlogClient getClient(final BlogType blogType) {

--- a/backend/src/main/java/org/donggle/backend/domain/blog/PublishStatus.java
+++ b/backend/src/main/java/org/donggle/backend/domain/blog/PublishStatus.java
@@ -1,6 +1,7 @@
 package org.donggle.backend.domain.blog;
 
 import lombok.Getter;
+import org.donggle.backend.exception.business.InvalidPublishRequestException;
 
 import java.util.Arrays;
 
@@ -22,6 +23,6 @@ public enum PublishStatus {
         return Arrays.stream(PublishStatus.values())
                 .filter(status -> status.name().equalsIgnoreCase(publishStatus))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("발행 상태 정보가 잘못 입력되었습니다."));
+                .orElseThrow(() -> new InvalidPublishRequestException("발행 상태 정보가 잘못 입력되었습니다."));
     }
 }

--- a/backend/src/main/java/org/donggle/backend/domain/blog/PublishStatus.java
+++ b/backend/src/main/java/org/donggle/backend/domain/blog/PublishStatus.java
@@ -1,0 +1,28 @@
+package org.donggle.backend.domain.blog;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum PublishStatus {
+    PUBLIC(3, "public"),
+    PRIVATE(0, "draft"),
+    PROTECT(1, "unlisted");
+
+    private final int tistory;
+
+    private final String medium;
+
+    PublishStatus(final int tistory, final String medium) {
+        this.tistory = tistory;
+        this.medium = medium;
+    }
+
+    public static PublishStatus from(final String publishStatus) {
+        return Arrays.stream(PublishStatus.values())
+                .filter(status -> status.name().equalsIgnoreCase(publishStatus))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("발행 상태 정보가 잘못 입력되었습니다."));
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/domain/blog/PublishStatus.java
+++ b/backend/src/main/java/org/donggle/backend/domain/blog/PublishStatus.java
@@ -11,7 +11,6 @@ public enum PublishStatus {
     PROTECT(1, "unlisted");
 
     private final int tistory;
-
     private final String medium;
 
     PublishStatus(final int tistory, final String medium) {

--- a/backend/src/main/java/org/donggle/backend/exception/business/InvalidPublishRequestException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/business/InvalidPublishRequestException.java
@@ -1,0 +1,24 @@
+package org.donggle.backend.exception.business;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidPublishRequestException extends BusinessException {
+    private static final String MESSAGE = "발행 정보가 잘못 입력되었습니다.";
+
+    private final String hint;
+
+    public InvalidPublishRequestException(final String hint) {
+        super(MESSAGE);
+        this.hint = hint;
+    }
+
+    @Override
+    public String getHint() {
+        return this.hint;
+    }
+
+    @Override
+    public int getErrorCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/medium/MediumApiClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/medium/MediumApiClient.java
@@ -1,7 +1,9 @@
 package org.donggle.backend.infrastructure.client.medium;
 
 import org.donggle.backend.application.client.BlogClient;
+import org.donggle.backend.application.service.request.PublishRequest;
 import org.donggle.backend.domain.blog.BlogType;
+import org.donggle.backend.domain.blog.PublishStatus;
 import org.donggle.backend.infrastructure.client.exception.ClientException;
 import org.donggle.backend.infrastructure.client.exception.ClientInternalServerError;
 import org.donggle.backend.infrastructure.client.medium.dto.request.MediumRequestBody;
@@ -14,7 +16,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Objects;
 
 import static org.donggle.backend.domain.blog.BlogType.MEDIUM;
@@ -33,8 +34,8 @@ public class MediumApiClient implements BlogClient {
     }
 
     @Override
-    public PublishResponse publish(final String accessToken, final String content, final List<String> tags, final String titleValue) {
-        final MediumRequestBody body = makePublishRequest(titleValue, content, tags);
+    public PublishResponse publish(final String accessToken, final String content, final PublishRequest publishRequest, final String titleValue) {
+        final MediumRequestBody body = makePublishRequest(titleValue, content, publishRequest);
         return webClient.post()
                 .uri("/users/{userId}/posts", getUserId(accessToken))
                 .accept(MediaType.APPLICATION_JSON)
@@ -50,12 +51,13 @@ public class MediumApiClient implements BlogClient {
                 .block().data().toPublishResponse();
     }
 
-    private MediumRequestBody makePublishRequest(final String titleValue, final String content, final List<String> tags) {
+    private MediumRequestBody makePublishRequest(final String titleValue, final String content, final PublishRequest publishRequest) {
         return MediumRequestBody.builder()
                 .title(titleValue)
                 .content(content)
                 .contentFormat("html")
-                .tags(tags)
+                .tags(publishRequest.tags())
+                .publishStatus(PublishStatus.from(publishRequest.publishStatus()).getMedium())
                 .build();
     }
 

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
@@ -4,6 +4,7 @@ import org.donggle.backend.application.client.BlogClient;
 import org.donggle.backend.application.service.request.PublishRequest;
 import org.donggle.backend.domain.blog.BlogType;
 import org.donggle.backend.domain.blog.PublishStatus;
+import org.donggle.backend.exception.business.InvalidPublishRequestException;
 import org.donggle.backend.infrastructure.client.exception.ClientInternalServerError;
 import org.donggle.backend.infrastructure.client.tistory.dto.request.TistoryPublishPropertyRequest;
 import org.donggle.backend.infrastructure.client.tistory.dto.request.TistoryPublishRequest;
@@ -76,7 +77,7 @@ public class TistoryApiClient implements BlogClient {
                     .visibility(publishStatus.getTistory())
                     .category(publishRequest.categoryId())
                     .tag(String.join(",", publishRequest.tags()))
-                    .published(makePublished(publishRequest.publishTime()))
+                    .published(makePublishTime(publishRequest.publishTime()))
                     .password(publishRequest.password())
                     .build();
         }
@@ -89,18 +90,18 @@ public class TistoryApiClient implements BlogClient {
                 .visibility(publishStatus.getTistory())
                 .category(publishRequest.categoryId())
                 .tag(String.join(",", publishRequest.tags()))
-                .published(makePublished(publishRequest.publishTime()))
+                .published(makePublishTime(publishRequest.publishTime()))
                 .build();
     }
 
-    private String makePublished(final String publishTime) {
+    private String makePublishTime(final String publishTime) {
         if (publishTime.isBlank()) {
             return String.valueOf(LocalDateTime.now());
         }
         final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
         final LocalDateTime publishLocalDateTime = LocalDateTime.parse(publishTime, formatter);
         if (publishLocalDateTime.isBefore(LocalDateTime.now())) {
-            throw new IllegalArgumentException("현재 시간보다 과거의 시간은 입력될 수 없습니다.");
+            throw new InvalidPublishRequestException("현재 시간보다 과거의 시간은 입력될 수 없습니다.");
         }
         return publishTime;
     }

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
@@ -55,11 +55,11 @@ public class TistoryApiClient implements BlogClient {
         return TistoryPublishPropertyRequest.builder()
                 .access_token(accessToken)
                 .postId(postId)
-                .blogName(getDefaultTistoryBlogName(accessToken))
+                .blogName(findDefaultBlogName(accessToken))
                 .build();
     }
 
-    public TistoryPublishRequest makePublishRequest(
+    private TistoryPublishRequest makePublishRequest(
             final String accessToken,
             final String titleValue,
             final String content,
@@ -69,7 +69,7 @@ public class TistoryApiClient implements BlogClient {
         if (publishStatus == PublishStatus.PROTECT) {
             return TistoryPublishRequest.builder()
                     .access_token(accessToken)
-                    .blogName(getDefaultTistoryBlogName(accessToken))
+                    .blogName(findDefaultBlogName(accessToken))
                     .output("json")
                     .title(titleValue)
                     .content(content)
@@ -82,7 +82,7 @@ public class TistoryApiClient implements BlogClient {
         }
         return TistoryPublishRequest.builder()
                 .access_token(accessToken)
-                .blogName(getDefaultTistoryBlogName(accessToken))
+                .blogName(findDefaultBlogName(accessToken))
                 .output("json")
                 .title(titleValue)
                 .content(content)
@@ -105,7 +105,7 @@ public class TistoryApiClient implements BlogClient {
         return publishTime;
     }
 
-    public String getDefaultTistoryBlogName(final String access_token) {
+    public String findDefaultBlogName(final String access_token) {
         final String blogInfoUri = UriComponentsBuilder.fromUriString(TISTORY_URL)
                 .path("/blog/info")
                 .queryParam("access_token", access_token)
@@ -127,7 +127,7 @@ public class TistoryApiClient implements BlogClient {
                 .orElseThrow();
     }
 
-    public TistoryGetWritingResponseWrapper findPublishProperty(final TistoryPublishPropertyRequest request) {
+    private TistoryGetWritingResponseWrapper findPublishProperty(final TistoryPublishPropertyRequest request) {
         final String publishPropertyUri = UriComponentsBuilder.fromUriString("/post/read")
                 .queryParam("access_token", request.access_token())
                 .queryParam("blogName", request.blogName())

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
@@ -1,7 +1,9 @@
 package org.donggle.backend.infrastructure.client.tistory;
 
 import org.donggle.backend.application.client.BlogClient;
+import org.donggle.backend.application.service.request.PublishRequest;
 import org.donggle.backend.domain.blog.BlogType;
+import org.donggle.backend.domain.blog.PublishStatus;
 import org.donggle.backend.infrastructure.client.exception.ClientInternalServerError;
 import org.donggle.backend.infrastructure.client.tistory.dto.request.TistoryPublishPropertyRequest;
 import org.donggle.backend.infrastructure.client.tistory.dto.request.TistoryPublishRequest;
@@ -15,7 +17,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.List;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static org.donggle.backend.domain.blog.BlogType.TISTORY;
 import static org.donggle.backend.infrastructure.client.exception.ClientException.handle4xxException;
@@ -32,8 +35,8 @@ public class TistoryApiClient implements BlogClient {
     }
 
     @Override
-    public PublishResponse publish(final String accessToken, final String content, final List<String> tags, final String titleValue) {
-        final TistoryPublishRequest request = makePublishRequest(accessToken, titleValue, content, tags);
+    public PublishResponse publish(final String accessToken, final String content, final PublishRequest publishRequest, final String titleValue) {
+        final TistoryPublishRequest request = makePublishRequest(accessToken, titleValue, content, publishRequest);
         final TistoryPublishWritingResponseWrapper response = webClient.post()
                 .uri("/post/write?")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -60,16 +63,46 @@ public class TistoryApiClient implements BlogClient {
             final String accessToken,
             final String titleValue,
             final String content,
-            final List<String> tags
+            final PublishRequest publishRequest
     ) {
+        final PublishStatus publishStatus = PublishStatus.from(publishRequest.publishStatus());
+        if (publishStatus == PublishStatus.PROTECT) {
+            return TistoryPublishRequest.builder()
+                    .access_token(accessToken)
+                    .blogName(getDefaultTistoryBlogName(accessToken))
+                    .output("json")
+                    .title(titleValue)
+                    .content(content)
+                    .visibility(publishStatus.getTistory())
+                    .category(publishRequest.categoryId())
+                    .tag(String.join(",", publishRequest.tags()))
+                    .published(makePublished(publishRequest.publishTime()))
+                    .password(publishRequest.password())
+                    .build();
+        }
         return TistoryPublishRequest.builder()
                 .access_token(accessToken)
                 .blogName(getDefaultTistoryBlogName(accessToken))
                 .output("json")
                 .title(titleValue)
                 .content(content)
-                .tag(String.join(",", tags))
+                .visibility(publishStatus.getTistory())
+                .category(publishRequest.categoryId())
+                .tag(String.join(",", publishRequest.tags()))
+                .published(makePublished(publishRequest.publishTime()))
                 .build();
+    }
+
+    private String makePublished(final String publishTime) {
+        if (publishTime.isBlank()) {
+            return String.valueOf(LocalDateTime.now());
+        }
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+        final LocalDateTime publishLocalDateTime = LocalDateTime.parse(publishTime, formatter);
+        if (publishLocalDateTime.isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("현재 시간보다 과거의 시간은 입력될 수 없습니다.");
+        }
+        return publishTime;
     }
 
     public String getDefaultTistoryBlogName(final String access_token) {

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryConnectionClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryConnectionClient.java
@@ -2,12 +2,12 @@ package org.donggle.backend.infrastructure.client.tistory;
 
 import org.donggle.backend.application.repository.MemberCredentialsRepository;
 import org.donggle.backend.application.repository.MemberRepository;
-import org.donggle.backend.infrastructure.client.tistory.dto.response.TistoryAccessTokenResponse;
 import org.donggle.backend.application.service.request.OAuthAccessTokenRequest;
-import org.donggle.backend.infrastructure.client.exception.ClientException;
 import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.member.MemberCredentials;
 import org.donggle.backend.exception.notfound.MemberNotFoundException;
+import org.donggle.backend.infrastructure.client.exception.ClientException;
+import org.donggle.backend.infrastructure.client.tistory.dto.response.TistoryAccessTokenResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -23,7 +23,6 @@ import java.util.NoSuchElementException;
 public class TistoryConnectionClient {
     private static final String AUTHORIZE_URL = "https://www.tistory.com/oauth/authorize";
     private static final String TOKEN_URL = "https://www.tistory.com/oauth/access_token";
-    private static final String CLIENT_ID = "client_id";
     private static final String PLATFORM_NAME = "Tistory";
 
     private final String clientId;
@@ -48,7 +47,7 @@ public class TistoryConnectionClient {
 
     public String createAuthorizeRedirectUri(final String redirectUri) {
         return UriComponentsBuilder.fromUriString(AUTHORIZE_URL)
-                .queryParam(CLIENT_ID, clientId)
+                .queryParam("client_id", clientId)
                 .queryParam("redirect_uri", redirectUri)
                 .queryParam("response_type", "code")
                 .build()
@@ -60,7 +59,7 @@ public class TistoryConnectionClient {
         final MemberCredentials memberCredentials = findMemberCredentials(member);
 
         final String accessToken = getAccessToken(oAuthAccessTokenRequest.code(), oAuthAccessTokenRequest.redirect_uri());
-        final String tistoryBlogName = tistoryApiService.getDefaultTistoryBlogName(accessToken);
+        final String tistoryBlogName = tistoryApiService.findDefaultBlogName(accessToken);
 
         memberCredentials.updateTistory(accessToken, tistoryBlogName);
     }

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/dto/request/TistoryPublishRequest.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/dto/request/TistoryPublishRequest.java
@@ -12,7 +12,7 @@ public record TistoryPublishRequest(
         String title,
         String content,
         int visibility,
-        Long category,
+        String category,
         String published,
         List<String> slogan,
         String tag,

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/dto/request/TistoryPublishRequest.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/dto/request/TistoryPublishRequest.java
@@ -12,7 +12,7 @@ public record TistoryPublishRequest(
         String title,
         String content,
         int visibility,
-        int category,
+        Long category,
         String published,
         List<String> slogan,
         String tag,

--- a/backend/src/main/java/org/donggle/backend/ui/PublishController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/PublishController.java
@@ -1,0 +1,41 @@
+package org.donggle.backend.ui;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.donggle.backend.application.service.blog.PublishFacadeService;
+import org.donggle.backend.application.service.request.PublishRequest;
+import org.donggle.backend.domain.blog.BlogType;
+import org.donggle.backend.ui.common.AuthenticationPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/writings/{writingId}/publish")
+public class PublishController {
+    private final PublishFacadeService blogService;
+
+    @PostMapping("/tistory")
+    public ResponseEntity<Void> publishToTistory(
+            @AuthenticationPrincipal final Long memberId,
+            @PathVariable final Long writingId,
+            @Valid @RequestBody final PublishRequest request
+    ) {
+        blogService.publishWriting(memberId, writingId, BlogType.TISTORY, PublishRequest.tistory(request));
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/medium")
+    public ResponseEntity<Void> publishToMedium(
+            @AuthenticationPrincipal final Long memberId,
+            @PathVariable final Long writingId,
+            @Valid @RequestBody final PublishRequest request
+    ) {
+        blogService.publishWriting(memberId, writingId, BlogType.MEDIUM, PublishRequest.medium(request));
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/org/donggle/backend/ui/WritingController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/WritingController.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.donggle.backend.application.service.blog.PublishFacadeService;
 import org.donggle.backend.application.service.request.MarkdownUploadRequest;
 import org.donggle.backend.application.service.request.NotionUploadRequest;
-import org.donggle.backend.application.service.request.PublishRequest;
 import org.donggle.backend.application.service.request.WritingModifyRequest;
 import org.donggle.backend.application.service.writing.WritingFacadeService;
 import org.donggle.backend.ui.common.AuthenticationPrincipal;
@@ -92,15 +91,5 @@ public class WritingController {
     ) {
         final WritingListWithCategoryResponse response = writingFacadeService.findWritingListByCategoryId(memberId, categoryId);
         return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/{writingId}/publish")
-    public ResponseEntity<Void> writingPublish(
-            @AuthenticationPrincipal final Long memberId,
-            @PathVariable final Long writingId,
-            @Valid @RequestBody final PublishRequest request
-    ) {
-        blogService.publishWriting(memberId, writingId, request);
-        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/test/java/org/donggle/backend/application/service/PublishServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/PublishServiceTest.java
@@ -36,7 +36,7 @@ class PublishServiceTest {
     @DisplayName("중복 발행 금지 예외")
     void alreadyPublishedException() {
         //given
-        final PublishRequest medium = new PublishRequest("MEDIUM", null);
+        final PublishRequest medium = new PublishRequest(null, null, null, null, null);
         final Blog blog = blogRepository.findByBlogType(BlogType.MEDIUM).orElseThrow();
         final Writing writing = writingRepository.findById(1L).orElseThrow();
         blogWritingRepository.save(new BlogWriting(blog, writing, LocalDateTime.now(), null));
@@ -44,6 +44,6 @@ class PublishServiceTest {
 
         //when
         //then
-        assertThatThrownBy(() -> blogService.publishWriting(1L, 1L, medium)).isInstanceOf(WritingAlreadyPublishedException.class).hasMessageContaining("이미 발행된 글입니다.");
+        assertThatThrownBy(() -> blogService.publishWriting(1L, 1L, BlogType.MEDIUM, medium)).isInstanceOf(WritingAlreadyPublishedException.class).hasMessageContaining("이미 발행된 글입니다.");
     }
 }


### PR DESCRIPTION
### 🛠️ Issue

- close #422 

### ✅ Tasks
- 글 발행 API 분리 (PublishController)
- 티스토리 발행하기 API 수정
- 미디움 발행하기 API 수정

### ⏰ Time Difference
- +2

### 📝 Note
- API 테스트 결과 변경된 API로 제대로 발행되는 것을 확인했습니다.
- 티스토리 발행 선택 정보 중 `publishTime`의 DateTime 형식이 티스토리에서 요구하는 형식과 다른지 예약 기능이 제대로 되지 않아서 해당 부분은 조금 더 찾아봐야 할 것 같습니다 🥲

### 🫡 같이 의견 나눠보고 싶은 부분
1. PublishRequest 내부 예외 처리
    - 현재 `PublishController`에서 `PublishRequest`로 요청을 받아 서비스로 전달하고 있습니다. 이 때 각 api에 맞는 스펙으로 예외 검증을 하는 로직이 `PublishRequest` 내부에 있습니다.
    - 이렇게 구현하게 된 이유는 `publishService`에서부터 각 `ClientApi`까지 추상화되어 있어 블로그에 맞는 예외를 체크하려면 각 `ClientApi`까지 들어가야 합니다. 하지만 `publishService`에서 랜더링을 하고 있어서 랜더링이 시작되기 전에 예외를 던져줘서 불필요한 시간 낭비를 줄이고 싶었습니다.
    - 해당 검증 로직의 위치가 괜찮을지 얘기를 나눠보고 싶습니다.
2. 해당 API 의 예외 처리 로직..
    - 현재 `PublishRequest`와 `TistoryClientApi`에서 요청으로 들어온 값에 대한 검증을 한 뒤 `IllegalArgumentException`을 던지고 있습니다. 커스텀 예외처리를 해주고 싶은데 해당 검증이 비즈니스로직인가.. 에 대한 의문에 빠져 얘기를 나눠보고 싶습니다.

