### PR TITLE
[BE] fix: 카테고리 및 글 순서 이동 수정

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/service/category/CategoryService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/category/CategoryService.java
@@ -39,7 +39,7 @@ import static org.donggle.backend.domain.writing.WritingStatus.TRASHED;
 @Transactional
 @RequiredArgsConstructor
 public class CategoryService {
-    private static final int LAST_WRITING_FLAG = -1;
+    private static final int LAST_CATEGORY_FLAG = -1;
     private static final int FIRST_WRITING_INDEX = 0;
 
     private final MemberRepository memberRepository;
@@ -185,41 +185,65 @@ public class CategoryService {
     }
 
     public void modifyCategoryOrder(final Long memberId, final Long categoryId, final CategoryModifyRequest request) {
-        final Member member = findMember(memberId);
-        final Long nextCategoryId = request.nextCategoryId();
-        final Category source = findCategory(member.getId(), categoryId);
-        final Category basicCategory = findBasicCategoryByMemberId(member.getId());
-        validateBasicCategory(basicCategory, source);
-        if (deleteCategoryOrder(source)) {
+        final Long targetCategoryId = request.nextCategoryId();
+        final Category source = findCategory(memberId, categoryId);
+        validateAuthorization(source, memberId);
+        final Category basicCategory = findBasicCategoryByMemberId(memberId);
+        validateModifyCategoryOrder(basicCategory, categoryId, request.nextCategoryId());
+        if (isInValidRequest(source, request)) {
             return;
         }
-        addCategoryOrder(nextCategoryId, source, member.getId());
-    }
-
-    private boolean deleteCategoryOrder(final Category category) {
-        final Category nextCategory = category.getNextCategory();
-        category.changeNextCategoryNull();
-        final Category preCategory = findPreCategory(category.getId());
+        final Category nextCategory = source.getNextCategory();
+        final Category lastCategory = findLastCategoryByMemberId(memberId);
+        source.changeNextCategoryNull();
+        final Category preCategory = findPreCategory(source.getId());
         preCategory.changeNextCategory(nextCategory);
-        if (nextCategory.getNextCategory() == null) {
-            nextCategory.changeNextCategory(category);
-            return true;
+
+        if (targetCategoryId == LAST_CATEGORY_FLAG) {
+            lastCategory.changeNextCategory(source);
+        } else {
+            final Category targetCategory = findCategory(memberId, targetCategoryId);
+            final Category targetPreCategory = findPreCategory(targetCategoryId);
+            targetPreCategory.changeNextCategory(source);
+            categoryRepository.flush();
+            source.changeNextCategory(targetCategory);
         }
-        return false;
     }
 
-    private void addCategoryOrder(final Long nextCategoryId, final Category category, final Long memberId) {
-        final Category preCategory;
-        if (nextCategoryId == LAST_WRITING_FLAG) {
-            preCategory = findLastCategoryByMemberId(memberId);
-        } else {
-            preCategory = findPreCategory(nextCategoryId);
+    private void validateAuthorization(final Category category, final Long memberId) {
+        if (!category.getMember().getId().equals(memberId)) {
+            throw new CategoryNotFoundException(category.getId());
         }
-        preCategory.changeNextCategory(category);
-        if (nextCategoryId != LAST_WRITING_FLAG) {
-            final Category nextCategory = findCategory(memberId, nextCategoryId);
-            category.changeNextCategory(nextCategory);
+    }
+
+    private void validateModifyCategoryOrder(final Category basicCategory, final Long categoryId, final Long targetCategoryId) {
+        if (isMovingBasicCategory(basicCategory, categoryId, targetCategoryId)) {
+            throw new InvalidBasicCategoryException(categoryId, targetCategoryId);
         }
+    }
+
+    private boolean isMovingBasicCategory(final Category basicCategory, final Long categoryId, final Long targetCategoryId) {
+        return Objects.equals(basicCategory.getId(), categoryId) ||
+                Objects.equals(basicCategory.getId(), targetCategoryId);
+    }
+
+    private boolean isInValidRequest(final Category source, final CategoryModifyRequest request) {
+        return isAlreadyLast(source, request) ||
+                isSamePosition(source, request) ||
+                isSelfPointing(source, request);
+    }
+
+    private boolean isAlreadyLast(final Category source, final CategoryModifyRequest request) {
+        return source.getNextCategory() == null && request.nextCategoryId() == LAST_CATEGORY_FLAG;
+    }
+
+    private boolean isSamePosition(final Category source, final CategoryModifyRequest request) {
+        return source.getNextCategory() != null &&
+                Objects.equals(source.getNextCategory().getId(), request.nextCategoryId());
+    }
+
+    private boolean isSelfPointing(final Category source, final CategoryModifyRequest request) {
+        return Objects.equals(source.getId(), request.nextCategoryId());
     }
 
     private void validateBasicCategory(final Category basicCategory, final Category category) {

--- a/backend/src/main/java/org/donggle/backend/application/service/category/CategoryService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/category/CategoryService.java
@@ -190,15 +190,22 @@ public class CategoryService {
         final Category source = findCategory(member.getId(), categoryId);
         final Category basicCategory = findBasicCategoryByMemberId(member.getId());
         validateBasicCategory(basicCategory, source);
-        deleteCategoryOrder(source);
+        if (deleteCategoryOrder(source)) {
+            return;
+        }
         addCategoryOrder(nextCategoryId, source, member.getId());
     }
 
-    private void deleteCategoryOrder(final Category category) {
+    private boolean deleteCategoryOrder(final Category category) {
         final Category nextCategory = category.getNextCategory();
         category.changeNextCategoryNull();
         final Category preCategory = findPreCategory(category.getId());
         preCategory.changeNextCategory(nextCategory);
+        if (nextCategory.getNextCategory() == null) {
+            nextCategory.changeNextCategory(category);
+            return true;
+        }
+        return false;
     }
 
     private void addCategoryOrder(final Long nextCategoryId, final Category category, final Long memberId) {

--- a/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
@@ -97,10 +97,7 @@ public class WritingService {
     }
 
     public void modifyWritingTitle(final Long memberId, final Long writingId, final Title title) {
-        final Writing findWriting = findWritingById(writingId);
-        if (findWriting.getStatus() != ACTIVE) {
-            throw new IllegalArgumentException();
-        }
+        final Writing findWriting = findActiveWriting(writingId);
         validateAuthorization(memberId, findWriting);
         findWriting.updateTitle(title);
     }
@@ -237,11 +234,6 @@ public class WritingService {
                 Objects.equals(source.getId(), request.nextWritingId());
     }
 
-    private Writing findActiveWriting(Long writingId) {
-        return writingRepository.findByIdAndStatus(writingId, ACTIVE)
-                .orElseThrow(() -> new WritingNotFoundException(writingId));
-    }
-
     @Transactional(readOnly = true)
     public Page<WritingHomeResponse> findAll(final Long memberId, final Pageable pageable) {
         final Page<Writing> pagedWritings = writingRepository.findByMemberIdAndWritingStatusOrderByCreatedAtDesc(memberId, pageable);
@@ -281,6 +273,11 @@ public class WritingService {
                 .toList();
     }
 
+    private Writing findActiveWriting(Long writingId) {
+        return writingRepository.findByIdAndStatus(writingId, ACTIVE)
+                .orElseThrow(() -> new WritingNotFoundException(writingId));
+    }
+
     private Category findCategory(final Long memberId, final Long categoryId) {
         return categoryRepository.findByIdAndMemberId(categoryId, memberId)
                 .orElseThrow(() -> new CategoryNotFoundException(categoryId));
@@ -289,11 +286,6 @@ public class WritingService {
     private Writing findLastWritingInCategory(final Long categoryId) {
         return writingRepository.findLastWritingByCategoryId(categoryId)
                 .orElseThrow(IllegalStateException::new);
-    }
-
-    private Writing findWritingById(final Long writingId) {
-        return writingRepository.findById(writingId)
-                .orElseThrow(() -> new WritingNotFoundException(writingId));
     }
 
     private Writing findPreWriting(final Long writingId) {

--- a/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
@@ -39,8 +39,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.groupingBy;
 import static org.donggle.backend.domain.writing.BlockType.CODE_BLOCK;
 import static org.donggle.backend.domain.writing.BlockType.HORIZONTAL_RULES;
 import static org.donggle.backend.domain.writing.BlockType.IMAGE;
@@ -142,7 +142,9 @@ public class WritingService {
         }
         final Writing firstWriting = findFirstWriting(findWritings);
         final List<Writing> sortedWriting = sortWriting(findWritings, firstWriting);
-        final Map<Writing, List<BlogWriting>> blogWritings = blogWritingRepository.findWithFetch(sortedWriting).stream().collect(Collectors.groupingBy(BlogWriting::getWriting));
+        final Map<Writing, List<BlogWriting>> blogWritings = blogWritingRepository.findWithFetch(sortedWriting)
+                .stream()
+                .collect(groupingBy(BlogWriting::getWriting));
 
         final List<WritingDetailResponse> responses = sortedWriting.stream().map(writing -> {
             final List<PublishedDetailResponse> publishedDetailResponses = Optional.ofNullable(blogWritings.get(writing)).orElse(Collections.emptyList()).stream().map(PublishedDetailResponse::of).toList();
@@ -175,40 +177,69 @@ public class WritingService {
     }
 
     public void modifyWritingOrder(final Long memberId, final Long writingId, final WritingModifyRequest request) {
-        final Long nextWritingId = request.nextWritingId();
-        final Long targetCategoryId = request.targetCategoryId();
-        final Writing source = findWritingById(writingId);
+        final Long targetWritingId = request.nextWritingId();
+        final Writing source = findActiveWriting(writingId);
         validateAuthorization(memberId, source);
-        deleteWritingOrder(source);
-        addWritingOrder(memberId, targetCategoryId, nextWritingId, source);
-        changeCategory(memberId, targetCategoryId, source);
-    }
+        if (isInValidRequest(request, source)) {
+            return;
+        }
 
-    private void deleteWritingOrder(final Writing writing) {
-        final Writing nextWriting = writing.getNextWriting();
-        writing.changeNextWritingNull();
-
-        if (isNotFirstWriting(writing.getId())) {
-            final Writing preWriting = findPreWriting(writing.getId());
+        if (isNotFirstWriting(source.getId())) {
+            final Writing nextWriting = source.getNextWriting();
+            final Writing lastWriting = findLastWritingInCategory(request.targetCategoryId());
+            source.changeNextWritingNull();
+            final Writing preWriting = findPreWriting(source.getId());
             preWriting.changeNextWriting(nextWriting);
+            if (request.nextWritingId() == LAST_WRITING_FLAG) {
+                lastWriting.changeNextWriting(source);
+                changeCategory(memberId, request.targetCategoryId(), source);
+                return;
+            }
         }
+
+        if (request.nextWritingId() == LAST_WRITING_FLAG) {
+            final Writing lastWriting = findLastWritingInCategory(request.targetCategoryId());
+            lastWriting.changeNextWriting(source);
+            source.changeNextWritingNull();
+        } else {
+            final Writing targetWriting = findActiveWriting(targetWritingId);
+            final Optional<Writing> preWritingOptional = writingRepository.findPreWritingByWritingId(targetWritingId);
+            if (preWritingOptional.isEmpty()) {
+                source.changeNextWriting(targetWriting);
+            } else {
+                preWritingOptional.get().changeNextWriting(source);
+                writingRepository.flush();
+                source.changeNextWriting(targetWriting);
+            }
+        }
+        changeCategory(memberId, request.targetCategoryId(), source);
     }
 
-    private void addWritingOrder(final Long memberId, final Long categoryId, final Long nextWritingId, final Writing writing) {
-        if (isNotFirstWriting(nextWritingId)) {
-            final Writing preWriting;
-            if (nextWritingId == LAST_WRITING_FLAG) {
-                preWriting = findLastWritingInCategory(categoryId);
-            } else {
-                preWriting = findPreWriting(nextWritingId);
-            }
-            preWriting.changeNextWriting(writing);
-        }
-        if (nextWritingId != LAST_WRITING_FLAG) {
-            final Writing nextWriting = findWritingById(nextWritingId);
-            validateAuthorization(memberId, nextWriting);
-            writing.changeNextWriting(nextWriting);
-        }
+    private boolean isInValidRequest(final WritingModifyRequest request, final Writing source) {
+        return isAlreadyLastInSameCategory(request, source) ||
+                isSamePosition(source, request) ||
+                isSelfPointing(source, request);
+    }
+
+    private boolean isAlreadyLastInSameCategory(final WritingModifyRequest request, final Writing source) {
+        return source.getNextWriting() == null &&
+                request.nextWritingId() == LAST_WRITING_FLAG &&
+                request.targetCategoryId().equals(source.getCategory().getId());
+    }
+
+    private boolean isSamePosition(final Writing source, final WritingModifyRequest request) {
+        return source.getNextWriting() != null &&
+                Objects.equals(source.getNextWriting().getId(), request.nextWritingId());
+    }
+
+    private static boolean isSelfPointing(final Writing source, final WritingModifyRequest request) {
+        return source.getNextWriting() != null &&
+                Objects.equals(source.getId(), request.nextWritingId());
+    }
+
+    private Writing findActiveWriting(Long writingId) {
+        return writingRepository.findByIdAndStatus(writingId, ACTIVE)
+                .orElseThrow(() -> new WritingNotFoundException(writingId));
     }
 
     @Transactional(readOnly = true)
@@ -238,7 +269,9 @@ public class WritingService {
 
     private List<PublishedDetailResponse> convertToPublishedDetailResponses(final Long findWriting) {
         final List<BlogWriting> blogWritings = blogWritingRepository.findByWritingId(findWriting);
-        return blogWritings.stream().map(PublishedDetailResponse::of).toList();
+        return blogWritings.stream()
+                .map(PublishedDetailResponse::of)
+                .toList();
     }
 
     private List<PublishedDetailSimpleResponse> convertToPublishedDetailSimpleResponses(final Long findWriting) {
@@ -249,7 +282,8 @@ public class WritingService {
     }
 
     private Category findCategory(final Long memberId, final Long categoryId) {
-        return categoryRepository.findByIdAndMemberId(categoryId, memberId).orElseThrow(() -> new CategoryNotFoundException(categoryId));
+        return categoryRepository.findByIdAndMemberId(categoryId, memberId)
+                .orElseThrow(() -> new CategoryNotFoundException(categoryId));
     }
 
     private Writing findLastWritingInCategory(final Long categoryId) {

--- a/backend/src/main/java/org/donggle/backend/domain/writing/Writing.java
+++ b/backend/src/main/java/org/donggle/backend/domain/writing/Writing.java
@@ -84,10 +84,6 @@ public class Writing extends BaseEntity {
         changeNextWritingNull();
     }
 
-    public String getTitleValue() {
-        return this.title.getTitle();
-    }
-
     public void changeCategory(final Category category) {
         this.category = category;
     }
@@ -107,6 +103,10 @@ public class Writing extends BaseEntity {
 
     public boolean isOwnedBy(final Long memberId) {
         return getMember().getId().equals(memberId);
+    }
+
+    public String getTitleValue() {
+        return this.title.getTitle();
     }
 
     @Override

--- a/backend/src/main/java/org/donggle/backend/exception/business/InvalidBasicCategoryException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/business/InvalidBasicCategoryException.java
@@ -4,24 +4,27 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidBasicCategoryException extends BusinessException {
     private static final String MESSAGE = "기본 카테고리는 변경이 불가합니다.";
-    
-    private final Long categoryId;
 
-    public InvalidBasicCategoryException(final Long categoryId) {
+    private final Long sourceCategoryId;
+    private final Long targetCategoryId;
+
+    public InvalidBasicCategoryException(final Long sourceCategoryId) {
         super(MESSAGE);
-        this.categoryId = categoryId;
+        this.sourceCategoryId = sourceCategoryId;
+        this.targetCategoryId = 0L;
     }
 
-    public InvalidBasicCategoryException(final Long categoryId, final Throwable cause) {
-        super(MESSAGE, cause);
-        this.categoryId = categoryId;
+    public InvalidBasicCategoryException(final Long sourceCategoryId, final Long targetCategoryId) {
+        super(MESSAGE);
+        this.sourceCategoryId = sourceCategoryId;
+        this.targetCategoryId = targetCategoryId;
     }
-    
+
     @Override
     public String getHint() {
-        return "기본 카테고리는 변경이 불가합니다. 입력한 id: " + categoryId;
+        return "기본 카테고리는 변경이 불가합니다. 입력한 source id: " + sourceCategoryId + " target id:" + targetCategoryId;
     }
-    
+
     @Override
     public int getErrorCode() {
         return HttpStatus.BAD_REQUEST.value();

--- a/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
@@ -15,9 +15,7 @@ import org.donggle.backend.exception.business.OverLengthCategoryNameException;
 import org.donggle.backend.ui.response.CategoryListResponse;
 import org.donggle.backend.ui.response.CategoryResponse;
 import org.donggle.backend.ui.response.CategoryWritingsResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -198,64 +196,6 @@ class CategoryServiceTest {
                 () -> assertThat(response.writings()).isEmpty(),
                 () -> assertThat(response.categoryName()).isEqualTo("두 번째 카테고리")
         );
-    }
-
-    @Nested
-    class ModifyCategoryOrderTest {
-        private Long firstId = 1L;
-        private Long secondId;
-        private Long thirdId;
-
-        @BeforeEach
-        void setUp() {
-            //given
-            secondId = categoryService.addCategory(1L, new CategoryAddRequest("두 번째 카테고리"));
-            thirdId = categoryService.addCategory(1L, new CategoryAddRequest("세 번째 카테고리"));
-        }
-
-        @Test
-        @DisplayName("카테고리 순서 수정 테스트 - [1, 2, '3'] -> [1, '3', 2]")
-        void modifyCategoryOrder1() {
-            //when
-            categoryService.modifyCategoryOrder(1L, thirdId, new CategoryModifyRequest(null, secondId));
-
-            //then
-            final CategoryListResponse response = categoryService.findAll(1L);
-            assertAll(
-                    () -> assertThat(response.categories()).hasSize(3),
-                    () -> assertThat(response.categories()).containsExactly(
-                            new CategoryResponse(firstId, "기본"),
-                            new CategoryResponse(thirdId, "세 번째 카테고리"),
-                            new CategoryResponse(secondId, "두 번째 카테고리")
-                    )
-            );
-        }
-
-        @Test
-        @DisplayName("카테고리 순서 수정 테스트 - ['1', 2, 3] -> [2, 3, '1']")
-        void modifyCategoryOrder2() {
-            //when, then
-            assertThatThrownBy(() -> categoryService.modifyCategoryOrder(1L, firstId, new CategoryModifyRequest(null, -1L)))
-                    .isInstanceOf(InvalidBasicCategoryException.class);
-        }
-
-        @Test
-        @DisplayName("카테고리 순서 수정 테스트 - [1, '2', 3] -> [1, 3, '2']")
-        void modifyCategoryOrder3() {
-            //when
-            categoryService.modifyCategoryOrder(1L, secondId, new CategoryModifyRequest(null, -1L));
-
-            //then
-            final CategoryListResponse response = categoryService.findAll(1L);
-            assertAll(
-                    () -> assertThat(response.categories()).hasSize(3),
-                    () -> assertThat(response.categories()).containsExactly(
-                            new CategoryResponse(firstId, "기본"),
-                            new CategoryResponse(thirdId, "세 번째 카테고리"),
-                            new CategoryResponse(secondId, "두 번째 카테고리")
-                    )
-            );
-        }
     }
 
 

--- a/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/CategoryServiceTest.java
@@ -15,7 +15,9 @@ import org.donggle.backend.exception.business.OverLengthCategoryNameException;
 import org.donggle.backend.ui.response.CategoryListResponse;
 import org.donggle.backend.ui.response.CategoryResponse;
 import org.donggle.backend.ui.response.CategoryWritingsResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -193,33 +195,69 @@ class CategoryServiceTest {
 
         //then
         assertAll(
-                () -> assertThat(response.writings()).hasSize(0),
                 () -> assertThat(response.writings()).isEmpty(),
                 () -> assertThat(response.categoryName()).isEqualTo("두 번째 카테고리")
         );
     }
 
-    @Test
-    @DisplayName("카테고리 순서 수정 테스트")
-    void modifyCategoryOrder() {
-        //given
-        final Long secondId = categoryService.addCategory(1L, new CategoryAddRequest("두 번째 카테고리"));
-        final Long thirdId = categoryService.addCategory(1L, new CategoryAddRequest("세 번째 카테고리"));
+    @Nested
+    class ModifyCategoryOrderTest {
+        private Long firstId = 1L;
+        private Long secondId;
+        private Long thirdId;
 
-        //when
-        categoryService.modifyCategoryOrder(1L, thirdId, new CategoryModifyRequest(null, secondId));
+        @BeforeEach
+        void setUp() {
+            //given
+            secondId = categoryService.addCategory(1L, new CategoryAddRequest("두 번째 카테고리"));
+            thirdId = categoryService.addCategory(1L, new CategoryAddRequest("세 번째 카테고리"));
+        }
 
-        //then
-        final CategoryListResponse response = categoryService.findAll(1L);
-        assertAll(
-                () -> assertThat(response.categories()).hasSize(3),
-                () -> assertThat(response.categories()).containsExactly(
-                        new CategoryResponse(1L, "기본"),
-                        new CategoryResponse(thirdId, "세 번째 카테고리"),
-                        new CategoryResponse(secondId, "두 번째 카테고리")
-                )
-        );
+        @Test
+        @DisplayName("카테고리 순서 수정 테스트 - [1, 2, '3'] -> [1, '3', 2]")
+        void modifyCategoryOrder1() {
+            //when
+            categoryService.modifyCategoryOrder(1L, thirdId, new CategoryModifyRequest(null, secondId));
+
+            //then
+            final CategoryListResponse response = categoryService.findAll(1L);
+            assertAll(
+                    () -> assertThat(response.categories()).hasSize(3),
+                    () -> assertThat(response.categories()).containsExactly(
+                            new CategoryResponse(firstId, "기본"),
+                            new CategoryResponse(thirdId, "세 번째 카테고리"),
+                            new CategoryResponse(secondId, "두 번째 카테고리")
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("카테고리 순서 수정 테스트 - ['1', 2, 3] -> [2, 3, '1']")
+        void modifyCategoryOrder2() {
+            //when, then
+            assertThatThrownBy(() -> categoryService.modifyCategoryOrder(1L, firstId, new CategoryModifyRequest(null, -1L)))
+                    .isInstanceOf(InvalidBasicCategoryException.class);
+        }
+
+        @Test
+        @DisplayName("카테고리 순서 수정 테스트 - [1, '2', 3] -> [1, 3, '2']")
+        void modifyCategoryOrder3() {
+            //when
+            categoryService.modifyCategoryOrder(1L, secondId, new CategoryModifyRequest(null, -1L));
+
+            //then
+            final CategoryListResponse response = categoryService.findAll(1L);
+            assertAll(
+                    () -> assertThat(response.categories()).hasSize(3),
+                    () -> assertThat(response.categories()).containsExactly(
+                            new CategoryResponse(firstId, "기본"),
+                            new CategoryResponse(thirdId, "세 번째 카테고리"),
+                            new CategoryResponse(secondId, "두 번째 카테고리")
+                    )
+            );
+        }
     }
+
 
     @Test
     @DisplayName("카테고리 이름 중복 예외")

--- a/backend/src/test/java/org/donggle/backend/application/service/ModifyCategoryOrderTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/ModifyCategoryOrderTest.java
@@ -1,0 +1,215 @@
+package org.donggle.backend.application.service;
+
+import org.donggle.backend.application.repository.CategoryRepository;
+import org.donggle.backend.application.repository.MemberRepository;
+import org.donggle.backend.application.service.category.CategoryService;
+import org.donggle.backend.application.service.request.CategoryModifyRequest;
+import org.donggle.backend.domain.category.Category;
+import org.donggle.backend.domain.category.CategoryName;
+import org.donggle.backend.domain.member.Member;
+import org.donggle.backend.domain.member.MemberName;
+import org.donggle.backend.domain.oauth.SocialType;
+import org.donggle.backend.exception.business.InvalidBasicCategoryException;
+import org.donggle.backend.ui.response.CategoryListResponse;
+import org.donggle.backend.ui.response.CategoryResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Transactional
+@SpringBootTest
+class ModifyCategoryOrderTest {
+
+    @Autowired
+    private CategoryService categoryService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    private Member member;
+    private Category basicCategory;
+    private Category secondCategory;
+    private Category thirdCategory;
+    private Category fourthCategory;
+
+    @BeforeEach
+    void setUp() {
+        //given
+        member = memberRepository.save(Member.of(
+                new MemberName("테스트 멤버"),
+                1234L,
+                SocialType.KAKAO
+        ));
+
+        basicCategory = categoryRepository.save(Category.of(new CategoryName("기본"), member));
+        secondCategory = categoryRepository.save(Category.of(new CategoryName("두 번째 카테고리"), member));
+        thirdCategory = categoryRepository.save(Category.of(new CategoryName("세 번째 카테고리"), member));
+        fourthCategory = categoryRepository.save(Category.of(new CategoryName("네 번째 카테고리"), member));
+
+        basicCategory.changeNextCategory(secondCategory);
+        secondCategory.changeNextCategory(thirdCategory);
+        thirdCategory.changeNextCategory(fourthCategory);
+    }
+
+    @Test
+    @DisplayName("[1, '2', 3, 4] -> [1, 3, '2', 4]")
+    void modifyCategoryOrder2() {
+        //when
+        categoryService.modifyCategoryOrder(member.getId(), secondCategory.getId(), new CategoryModifyRequest(null, fourthCategory.getId()));
+
+        //then
+        final CategoryListResponse response = categoryService.findAll(member.getId());
+        assertAll(
+                () -> assertThat(response.categories()).hasSize(4),
+                () -> assertThat(response.categories()).containsExactly(
+                        new CategoryResponse(basicCategory.getId(), "기본"),
+                        new CategoryResponse(thirdCategory.getId(), "세 번째 카테고리"),
+                        new CategoryResponse(secondCategory.getId(), "두 번째 카테고리"),
+                        new CategoryResponse(fourthCategory.getId(), "네 번째 카테고리")
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("[1, '2', 3, 4] -> [1, 3, 4, '2']")
+    void modifyCategoryOrder3() {
+        //when
+        categoryService.modifyCategoryOrder(member.getId(), secondCategory.getId(), new CategoryModifyRequest(null, -1L));
+
+        //then
+        final CategoryListResponse response = categoryService.findAll(member.getId());
+        assertAll(
+                () -> assertThat(response.categories()).hasSize(4),
+                () -> assertThat(response.categories()).containsExactly(
+                        new CategoryResponse(basicCategory.getId(), "기본"),
+                        new CategoryResponse(thirdCategory.getId(), "세 번째 카테고리"),
+                        new CategoryResponse(fourthCategory.getId(), "네 번째 카테고리"),
+                        new CategoryResponse(secondCategory.getId(), "두 번째 카테고리")
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("[1, 2, '3', 4] -> [1, '3', 2, 4]")
+    void modifyCategoryOrder4() {
+        //when
+        categoryService.modifyCategoryOrder(member.getId(), thirdCategory.getId(), new CategoryModifyRequest(null, secondCategory.getId()));
+
+        //then
+        final CategoryListResponse response = categoryService.findAll(member.getId());
+        assertAll(
+                () -> assertThat(response.categories()).hasSize(4),
+                () -> assertThat(response.categories()).containsExactly(
+                        new CategoryResponse(basicCategory.getId(), "기본"),
+                        new CategoryResponse(thirdCategory.getId(), "세 번째 카테고리"),
+                        new CategoryResponse(secondCategory.getId(), "두 번째 카테고리"),
+                        new CategoryResponse(fourthCategory.getId(), "네 번째 카테고리")
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("[1, 2, 3, '4'] -> [1, '4', 2, 3]")
+    void modifyCategoryOrder5() {
+        //when
+        categoryService.modifyCategoryOrder(member.getId(), fourthCategory.getId(), new CategoryModifyRequest(null, secondCategory.getId()));
+
+        //then
+        final CategoryListResponse response = categoryService.findAll(member.getId());
+        assertAll(
+                () -> assertThat(response.categories()).hasSize(4),
+                () -> assertThat(response.categories()).containsExactly(
+                        new CategoryResponse(basicCategory.getId(), "기본"),
+                        new CategoryResponse(fourthCategory.getId(), "네 번째 카테고리"),
+                        new CategoryResponse(secondCategory.getId(), "두 번째 카테고리"),
+                        new CategoryResponse(thirdCategory.getId(), "세 번째 카테고리")
+                )
+        );
+    }
+
+    @Nested
+    @DisplayName("예외적인 요청에 대한 처리")
+    class ExceptionalCategoryOrderModifyTest {
+        @Test
+        @DisplayName("['1', 2, 3, 4] -> [2, 3, 4, '1']")
+        void exceptionalModify1() {
+            //when, then
+            assertThatThrownBy(() -> categoryService.modifyCategoryOrder(member.getId(), basicCategory.getId(), new CategoryModifyRequest(null, -1L)))
+                    .isInstanceOf(InvalidBasicCategoryException.class);
+        }
+
+        @Test
+        @DisplayName("[1, 2, '3', 4] -> ['3', 1, 2, 4]")
+        void exceptionalModify2() {
+            //when
+            assertThatThrownBy(() -> categoryService.modifyCategoryOrder(member.getId(), thirdCategory.getId(), new CategoryModifyRequest(null, basicCategory.getId())))
+                    .isInstanceOf(InvalidBasicCategoryException.class);
+        }
+
+        @Test
+        @DisplayName("[1, '2', 3, 4] -> [1, '2', 3, 4]")
+        void exceptionalModify3() {
+            //when
+            categoryService.modifyCategoryOrder(member.getId(), secondCategory.getId(), new CategoryModifyRequest(null, thirdCategory.getId()));
+
+            //then
+            final CategoryListResponse response = categoryService.findAll(member.getId());
+            assertAll(
+                    () -> assertThat(response.categories()).hasSize(4),
+                    () -> assertThat(response.categories()).containsExactly(
+                            new CategoryResponse(basicCategory.getId(), "기본"),
+                            new CategoryResponse(secondCategory.getId(), "두 번째 카테고리"),
+                            new CategoryResponse(thirdCategory.getId(), "세 번째 카테고리"),
+                            new CategoryResponse(fourthCategory.getId(), "네 번째 카테고리")
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("[1, '2', 3, 4] -> [1, '2', 3, 4] (자기 자신을 참조)")
+        void exceptionalModify4() {
+            //when
+            categoryService.modifyCategoryOrder(member.getId(), secondCategory.getId(), new CategoryModifyRequest(null, secondCategory.getId()));
+
+            //then
+            final CategoryListResponse response = categoryService.findAll(member.getId());
+            assertAll(
+                    () -> assertThat(response.categories()).hasSize(4),
+                    () -> assertThat(response.categories()).containsExactly(
+                            new CategoryResponse(basicCategory.getId(), "기본"),
+                            new CategoryResponse(secondCategory.getId(), "두 번째 카테고리"),
+                            new CategoryResponse(thirdCategory.getId(), "세 번째 카테고리"),
+                            new CategoryResponse(fourthCategory.getId(), "네 번째 카테고리")
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("[1, 2, 3, '4'] -> [1, 2, 3, '4']")
+        void exceptionalModify5() {
+            //when
+            categoryService.modifyCategoryOrder(member.getId(), fourthCategory.getId(), new CategoryModifyRequest(null, -1L));
+
+            //then
+            final CategoryListResponse response = categoryService.findAll(member.getId());
+            assertAll(
+                    () -> assertThat(response.categories()).hasSize(4),
+                    () -> assertThat(response.categories()).containsExactly(
+                            new CategoryResponse(basicCategory.getId(), "기본"),
+                            new CategoryResponse(secondCategory.getId(), "두 번째 카테고리"),
+                            new CategoryResponse(thirdCategory.getId(), "세 번째 카테고리"),
+                            new CategoryResponse(fourthCategory.getId(), "네 번째 카테고리")
+                    )
+            );
+        }
+    }
+}

--- a/backend/src/test/java/org/donggle/backend/application/service/ModifyWritingOrderTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/ModifyWritingOrderTest.java
@@ -1,0 +1,783 @@
+package org.donggle.backend.application.service;
+
+import org.donggle.backend.application.repository.CategoryRepository;
+import org.donggle.backend.application.repository.MemberRepository;
+import org.donggle.backend.application.repository.WritingRepository;
+import org.donggle.backend.application.service.request.WritingModifyRequest;
+import org.donggle.backend.application.service.writing.WritingFacadeService;
+import org.donggle.backend.domain.category.Category;
+import org.donggle.backend.domain.category.CategoryName;
+import org.donggle.backend.domain.member.Member;
+import org.donggle.backend.domain.member.MemberName;
+import org.donggle.backend.domain.oauth.SocialType;
+import org.donggle.backend.domain.writing.BlockType;
+import org.donggle.backend.domain.writing.Style;
+import org.donggle.backend.domain.writing.StyleRange;
+import org.donggle.backend.domain.writing.StyleType;
+import org.donggle.backend.domain.writing.Title;
+import org.donggle.backend.domain.writing.Writing;
+import org.donggle.backend.domain.writing.block.Depth;
+import org.donggle.backend.domain.writing.block.NormalBlock;
+import org.donggle.backend.domain.writing.block.RawText;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.donggle.backend.domain.writing.WritingStatus.ACTIVE;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Transactional
+@SpringBootTest
+class ModifyWritingOrderTest {
+    @Autowired
+    private WritingFacadeService writingService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private WritingRepository writingRepository;
+
+    private Member member;
+    private Category basicCategory;
+    private Category anotherCategory;
+    private List<Writing> basicWritings = new ArrayList<>();
+    private List<Writing> anotherWritings = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(Member.of(
+                new MemberName("테스트 멤버"),
+                1234L,
+                SocialType.KAKAO
+        ));
+        basicCategory = categoryRepository.save(Category.of(new CategoryName("기본"), member));
+        anotherCategory = categoryRepository.save(Category.of(new CategoryName("추가"), member));
+
+        Writing target1 = null;
+        for (int i = 1; i <= 4; i++) {
+            final Writing basicWriting = writingRepository.save(
+                    Writing.of(member, new Title("기본 글" + i),
+                            basicCategory,
+                            List.of(new NormalBlock(
+                                    Depth.from(1),
+                                    BlockType.PARAGRAPH,
+                                    RawText.from("테스트 글입니다."),
+                                    List.of(new Style(new StyleRange(0, 2), StyleType.BOLD)))
+                            )
+                    )
+            );
+            basicWritings.add(basicWriting);
+            if (i == 1) {
+                target1 = basicWriting;
+            } else {
+                target1.changeNextWriting(basicWriting);
+                target1 = basicWriting;
+            }
+        }
+
+        Writing target2 = null;
+        for (int i = 1; i <= 4; i++) {
+            final Writing anotherWriting = writingRepository.save(
+                    Writing.of(member, new Title("추가 글" + i),
+                            anotherCategory,
+                            List.of(new NormalBlock(
+                                    Depth.from(1),
+                                    BlockType.PARAGRAPH,
+                                    RawText.from("테스트 글입니다."),
+                                    List.of(new Style(new StyleRange(0, 2), StyleType.BOLD)))
+                            )
+                    )
+            );
+            anotherWritings.add(anotherWriting);
+            if (i == 1) {
+                target2 = anotherWriting;
+            } else {
+                target2.changeNextWriting(anotherWriting);
+                target2 = anotherWriting;
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("하나의 카테고리 내에서 움직이는 경우")
+    class MovingInOneCategoryTest {
+        @Test
+        @DisplayName("[기본]['1', 2, 3, 4] -> [기본][2, '1', 3, 4]")
+        void movingInOneCategory1() {
+            // given
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(0).getId(),
+                    new WritingModifyRequest(null, basicCategory.getId(), basicWritings.get(2).getId())
+            );
+
+            final List<Writing> writings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(writings).hasSize(4);
+            final List<Writing> nextWritings = writings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            //when
+            writings.removeAll(nextWritings);
+
+            //then
+            final Writing firstWriting = writings.get(0);
+            assertAll(
+                    () -> assertThat(firstWriting).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(firstWriting.getNextWriting()).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본]['1', 2, 3, 4] -> [기본][2, 3, 4, '1']")
+        void movingInOneCategory2() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(0).getId(),
+                    new WritingModifyRequest(null, basicCategory.getId(), -1L)
+            );
+
+            final List<Writing> writings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(writings).hasSize(4);
+            final List<Writing> nextWritings = writings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            //when
+            writings.removeAll(nextWritings);
+
+            //then
+            final Writing firstWriting = writings.get(0);
+            assertAll(
+                    () -> assertThat(firstWriting).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(firstWriting.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, '2', 3, 4] -> [기본][1, 3, '2', 4]")
+        void movingInOneCategory3() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(1).getId(),
+                    new WritingModifyRequest(null, basicCategory.getId(), basicWritings.get(3).getId())
+            );
+
+            final List<Writing> writings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(writings).hasSize(4);
+            final List<Writing> nextWritings = writings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            //when
+            writings.removeAll(nextWritings);
+
+            //then
+            final Writing firstWriting = writings.get(0);
+            assertAll(
+                    () -> assertThat(firstWriting).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(firstWriting.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, '2', 3, 4] -> [기본][1, 3, 4, '2']")
+        void movingInOneCategory4() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(1).getId(),
+                    new WritingModifyRequest(null, basicCategory.getId(), -1L)
+            );
+
+            final List<Writing> writings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(writings).hasSize(4);
+            final List<Writing> nextWritings = writings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            writings.removeAll(nextWritings);
+
+            //then
+            final Writing firstWriting = writings.get(0);
+            assertAll(
+                    () -> assertThat(firstWriting).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(firstWriting.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, 2, 3, '4'] -> [기본][1, '4', 2, 3]")
+        void movingInOneCategory5() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(3).getId(),
+                    new WritingModifyRequest(null, basicCategory.getId(), basicWritings.get(1).getId())
+            );
+
+            final List<Writing> writings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(writings).hasSize(4);
+            final List<Writing> nextWritings = writings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            writings.removeAll(nextWritings);
+
+            //then
+            final Writing firstWriting = writings.get(0);
+            assertAll(
+                    () -> assertThat(firstWriting).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(firstWriting.getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, 2, 3, '4'] -> [기본]['4', 1, 2, 3]")
+        void movingInOneCategory6() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(3).getId(),
+                    new WritingModifyRequest(null, basicCategory.getId(), basicWritings.get(0).getId())
+            );
+
+            final List<Writing> writings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(writings).hasSize(4);
+            final List<Writing> nextWritings = writings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            writings.removeAll(nextWritings);
+
+            //then
+            final Writing firstWriting = writings.get(0);
+            assertAll(
+                    () -> assertThat(firstWriting).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(firstWriting.getNextWriting()).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Nested
+        @DisplayName("예외적인 요청에 대한 처리")
+        class ExceptionalMovingTest {
+            /**
+             * 원래의 순서 그대로 요청이 들어올 경우, early return하고 예외 없이 순서를 유지한다.
+             */
+            @Test
+            @DisplayName("[기본][1, '2', 3, 4] -> [기본][1, '2', 3, 4]")
+            void exceptionalMoving1() {
+                //when
+                writingService.modifyWritingOrder(
+                        member.getId(),
+                        basicWritings.get(1).getId(),
+                        new WritingModifyRequest(null, basicCategory.getId(),
+                                basicWritings.get(2).getId())
+                );
+
+                final List<Writing> writings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+                assertThat(writings).hasSize(4);
+                final List<Writing> nextWritings = writings.stream()
+                        .map(Writing::getNextWriting)
+                        .toList();
+
+                writings.removeAll(nextWritings);
+
+                //then
+                final Writing firstWriting = writings.get(0);
+                assertAll(
+                        () -> assertThat(firstWriting).isEqualTo(basicWritings.get(0)),
+                        () -> assertThat(firstWriting.getNextWriting()).isEqualTo(basicWritings.get(1)),
+                        () -> assertThat(firstWriting.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                        () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                        () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+                );
+            }
+
+            /**
+             * 원래의 순서 그대로 요청이 들어올 경우, early return하고 예외 없이 순서를 유지한다. (이미 마지막인데, 마지막으로 이동 요청이 올 경우)
+             */
+            @Test
+            @DisplayName("[기본][1, 2, 3, '4'] -> [기본][1, 2, 3, '4']")
+            void exceptionalMoving2() {
+                //when
+                writingService.modifyWritingOrder(
+                        member.getId(),
+                        basicWritings.get(3).getId(),
+                        new WritingModifyRequest(null, basicCategory.getId(), -1L)
+                );
+
+                final List<Writing> writings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+                assertThat(writings).hasSize(4);
+                final List<Writing> nextWritings = writings.stream()
+                        .map(Writing::getNextWriting)
+                        .toList();
+
+                writings.removeAll(nextWritings);
+
+                //then
+                final Writing firstWriting = writings.get(0);
+                assertAll(
+                        () -> assertThat(firstWriting).isEqualTo(basicWritings.get(0)),
+                        () -> assertThat(firstWriting.getNextWriting()).isEqualTo(basicWritings.get(1)),
+                        () -> assertThat(firstWriting.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                        () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                        () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+                );
+            }
+
+            /**
+             * 요청이 자기 자신을 가리키도록 한다면, 이를 무시하고 early return한다. 또한 예외 없이 순서를 유지한다.
+             */
+            @Test
+            @DisplayName("[기본][1, '2', 3, 4] -> [기본][1, '2', 3, 4]")
+            void modifyWritingOrder9() {
+                //when
+                writingService.modifyWritingOrder(
+                        member.getId(),
+                        basicWritings.get(1).getId(),
+                        new WritingModifyRequest(null, basicCategory.getId(), basicWritings.get(1).getId())
+                );
+
+                final List<Writing> writings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+                assertThat(writings).hasSize(4);
+                final List<Writing> nextWritings = writings.stream()
+                        .map(Writing::getNextWriting)
+                        .toList();
+
+                writings.removeAll(nextWritings);
+
+                //then
+                final Writing firstWriting = writings.get(0);
+                assertAll(
+                        () -> assertThat(firstWriting).isEqualTo(basicWritings.get(0)),
+                        () -> assertThat(firstWriting.getNextWriting()).isEqualTo(basicWritings.get(1)),
+                        () -> assertThat(firstWriting.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                        () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                        () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+                );
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("두 개의 카테고리에서 움직이는 경우")
+    class MovingInTwoCategoriesTest {
+        @Test
+        @DisplayName("[기본]['1', 2, 3, 4]/[추가][5, 6, 7, 8] -> [기본][2, 3, 4]/[추가]['1', 5, 6, 7, 8]")
+        void MovingInTwoCategories1() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(0).getId(),
+                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(0).getId())
+            );
+
+            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(basicCategoryWritings).hasSize(3);
+            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+            assertThat(anotherCategoryWritings).hasSize(5);
+            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            basicCategoryWritings.removeAll(basicNextWritings);
+            anotherCategoryWritings.removeAll(anotherNextWritings);
+
+            //then
+            final Writing basic1Writing = basicCategoryWritings.get(0);
+            final Writing another1Writing = anotherCategoryWritings.get(0);
+            assertAll(
+                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                    () -> assertThat(another1Writing).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본]['1', 2, 3, 4]/[추가][5, 6, 7, 8] -> [기본][2, 3, 4]/[추가][5, '1', 6, 7, 8]")
+        void MovingInTwoCategories2() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(0).getId(),
+                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(1).getId())
+            );
+
+            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(basicCategoryWritings).hasSize(3);
+            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+            assertThat(anotherCategoryWritings).hasSize(5);
+            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            basicCategoryWritings.removeAll(basicNextWritings);
+            anotherCategoryWritings.removeAll(anotherNextWritings);
+
+            //then
+            final Writing basic1Writing = basicCategoryWritings.get(0);
+            final Writing another1Writing = anotherCategoryWritings.get(0);
+            assertAll(
+                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본]['1', 2, 3, 4]/[추가][5, 6, 7, 8] -> [기본][2, 3, 4]/[추가][5, 6, 7, 8, '1']")
+        void MovingInTwoCategories3() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(0).getId(),
+                    new WritingModifyRequest(null, anotherCategory.getId(), -1L)
+            );
+
+            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(basicCategoryWritings).hasSize(3);
+            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+            assertThat(anotherCategoryWritings).hasSize(5);
+            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            basicCategoryWritings.removeAll(basicNextWritings);
+            anotherCategoryWritings.removeAll(anotherNextWritings);
+
+            //then
+            final Writing basic1Writing = basicCategoryWritings.get(0);
+            final Writing another1Writing = anotherCategoryWritings.get(0);
+            assertAll(
+                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, '2', 3, 4]/[추가][5, 6, 7, 8] -> [기본][1, 3, 4]/[추가]['2', 5, 6, 7, 8]")
+        void MovingInTwoCategories4() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(1).getId(),
+                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(0).getId())
+            );
+
+            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(basicCategoryWritings).hasSize(3);
+            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+            assertThat(anotherCategoryWritings).hasSize(5);
+            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            basicCategoryWritings.removeAll(basicNextWritings);
+            anotherCategoryWritings.removeAll(anotherNextWritings);
+
+            //then
+            final Writing basic1Writing = basicCategoryWritings.get(0);
+            final Writing another1Writing = anotherCategoryWritings.get(0);
+            assertAll(
+                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                    () -> assertThat(another1Writing).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, '2', 3, 4]/[추가][5, 6, 7, 8] -> [기본][1, 3, 4]/[추가][5, 6, '2', 7, 8]")
+        void MovingInTwoCategories5() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(1).getId(),
+                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(2).getId())
+            );
+
+            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(basicCategoryWritings).hasSize(3);
+            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+            assertThat(anotherCategoryWritings).hasSize(5);
+            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            basicCategoryWritings.removeAll(basicNextWritings);
+            anotherCategoryWritings.removeAll(anotherNextWritings);
+
+            //then
+            final Writing basic1Writing = basicCategoryWritings.get(0);
+            final Writing another1Writing = anotherCategoryWritings.get(0);
+            assertAll(
+                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, '2', 3, 4]/[추가][5, 6, 7, 8] -> [기본][1, 3, 4]/[추가][5, 6, 7, 8, '2']")
+        void MovingInTwoCategories6() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(1).getId(),
+                    new WritingModifyRequest(null, anotherCategory.getId(), -1L)
+            );
+
+            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(basicCategoryWritings).hasSize(3);
+            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+            assertThat(anotherCategoryWritings).hasSize(5);
+            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            basicCategoryWritings.removeAll(basicNextWritings);
+            anotherCategoryWritings.removeAll(anotherNextWritings);
+
+            //then
+            final Writing basic1Writing = basicCategoryWritings.get(0);
+            final Writing another1Writing = anotherCategoryWritings.get(0);
+            assertAll(
+                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, 2, 3, '4']/[추가][5, 6, 7, 8] -> [기본][1, 2, 3]/[추가]['4', 5, 6, 7, 8]")
+        void MovingInTwoCategories7() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(3).getId(),
+                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(0).getId())
+            );
+
+            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(basicCategoryWritings).hasSize(3);
+            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+            assertThat(anotherCategoryWritings).hasSize(5);
+            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            basicCategoryWritings.removeAll(basicNextWritings);
+            anotherCategoryWritings.removeAll(anotherNextWritings);
+
+            //then
+            final Writing basic1Writing = basicCategoryWritings.get(0);
+            final Writing another1Writing = anotherCategoryWritings.get(0);
+            assertAll(
+                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                    () -> assertThat(another1Writing).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, 2, 3, '4']/[추가][5, 6, 7, 8] -> [기본][1, 2, 3]/[추가][5, 6, '4', 7, 8]")
+        void MovingInTwoCategories8() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(3).getId(),
+                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(2).getId())
+            );
+
+            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(basicCategoryWritings).hasSize(3);
+            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+            assertThat(anotherCategoryWritings).hasSize(5);
+            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            basicCategoryWritings.removeAll(basicNextWritings);
+            anotherCategoryWritings.removeAll(anotherNextWritings);
+
+            //then
+            final Writing basic1Writing = basicCategoryWritings.get(0);
+            final Writing another1Writing = anotherCategoryWritings.get(0);
+            assertAll(
+                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, 2, 3, '4']/[추가][5, 6, 7, 8] -> [기본][1, 2, 3]/[추가][5, 6, 7, 8, '4']")
+        void MovingInTwoCategories9() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(3).getId(),
+                    new WritingModifyRequest(null, anotherCategory.getId(), -1L)
+            );
+
+            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(basicCategoryWritings).hasSize(3);
+            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+            assertThat(anotherCategoryWritings).hasSize(5);
+            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            basicCategoryWritings.removeAll(basicNextWritings);
+            anotherCategoryWritings.removeAll(anotherNextWritings);
+
+            //then
+            final Writing basic1Writing = basicCategoryWritings.get(0);
+            final Writing another1Writing = anotherCategoryWritings.get(0);
+            assertAll(
+                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+    }
+}

--- a/backend/src/test/java/org/donggle/backend/application/service/ModifyWritingOrderTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/ModifyWritingOrderTest.java
@@ -230,8 +230,37 @@ class ModifyWritingOrderTest {
         }
 
         @Test
-        @DisplayName("[기본][1, 2, 3, '4'] -> [기본][1, '4', 2, 3]")
+        @DisplayName("[기본][1, '2', 3, 4] -> [기본]['2', 1, 3, 4]")
         void movingInOneCategory5() {
+            //when
+            writingService.modifyWritingOrder(
+                    member.getId(),
+                    basicWritings.get(1).getId(),
+                    new WritingModifyRequest(null, basicCategory.getId(), basicWritings.get(0).getId())
+            );
+
+            final List<Writing> writings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+            assertThat(writings).hasSize(4);
+            final List<Writing> nextWritings = writings.stream()
+                    .map(Writing::getNextWriting)
+                    .toList();
+
+            writings.removeAll(nextWritings);
+
+            //then
+            final Writing firstWriting = writings.get(0);
+            assertAll(
+                    () -> assertThat(firstWriting).isEqualTo(basicWritings.get(1)),
+                    () -> assertThat(firstWriting.getNextWriting()).isEqualTo(basicWritings.get(0)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                    () -> assertThat(firstWriting.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("[기본][1, 2, 3, '4'] -> [기본][1, '4', 2, 3]")
+        void movingInOneCategory6() {
             //when
             writingService.modifyWritingOrder(
                     member.getId(),
@@ -260,7 +289,7 @@ class ModifyWritingOrderTest {
 
         @Test
         @DisplayName("[기본][1, 2, 3, '4'] -> [기본]['4', 1, 2, 3]")
-        void movingInOneCategory6() {
+        void movingInOneCategory7() {
             //when
             writingService.modifyWritingOrder(
                     member.getId(),


### PR DESCRIPTION
### 🛠️ Issue

- close #454

### ✅ Tasks
- 카테고리의 순서 이동 수정
- 글의 순서 이동 수정
- 테스트 케이스 추가

### ⏰ Time Difference
- 2 -> 4.5

### 📝 Note
되도록 실제 환경과 유사한 테스트 케이스를 만들기 위해 `SpringBootTest`를 사용했습니다. 또한 독립적인 테스트를 위해서 해당 클래스에서 `@BeforeEach`을 활용해 더미 데이터를 생성해주었습니다. 이 때문에 조금 더 지저분해보이네요 ㅠㅠㅠ

가능한 모든 경우의 수를 테스트하려고 했습니다. 또한 중요한 순서 수정 로직 같은 경우에는 되도록이면 메서드 추출을 하지 않았습니다. 로직이 매우 복잡하기 때문에 이부분은 펼쳐놓는 것이 이해하기에 조금 더 편할 것이라고 생각했습니다! 월요일날 한 번 더 얘기 나눠봤으면 좋겠네요 ㅎㅎㅎ