### PR TITLE
[BE] fix: 글 순서 이동 수정

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
@@ -183,20 +183,21 @@ public class WritingService {
 
         if (isNotFirstWriting(source.getId())) {
             final Writing nextWriting = source.getNextWriting();
-            final Writing lastWriting = findLastWritingInCategory(request.targetCategoryId());
+            final Optional<Writing> lastWritingOptional = writingRepository.findLastWritingByCategoryId(request.targetCategoryId());
             source.changeNextWritingNull();
             final Writing preWriting = findPreWriting(source.getId());
             preWriting.changeNextWriting(nextWriting);
+            writingRepository.flush(); // !!!!
             if (request.nextWritingId() == LAST_WRITING_FLAG) {
-                lastWriting.changeNextWriting(source);
+                lastWritingOptional.ifPresent(lastWriting -> lastWriting.changeNextWriting(source));
                 changeCategory(memberId, request.targetCategoryId(), source);
                 return;
             }
         }
 
         if (request.nextWritingId() == LAST_WRITING_FLAG) {
-            final Writing lastWriting = findLastWritingInCategory(request.targetCategoryId());
-            lastWriting.changeNextWriting(source);
+            writingRepository.findLastWritingByCategoryId(request.targetCategoryId())
+                    .ifPresent(lastWriting -> lastWriting.changeNextWriting(source));
             source.changeNextWritingNull();
         } else {
             final Writing targetWriting = findActiveWriting(targetWritingId);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,11 +13,16 @@ spring:
     hibernate:
       ddl-auto: create
     show-sql: true
+  data:
+    web:
+      pageable:
+        default-page-size: 12
+        max-page-size: 50
 security:
   jwt:
     token:
       secret-key: 'wjdgustmdwjdgustmdwjdgustmdwjdgustmdwjdgustmdwjdgustmdwjdgustmdwjdgustmdwjdgustmdwjdgustmdwjdgustmdwjdgustmdwjdgustmd'
-      access-token-expire-length: 600000
+      access-token-expire-length: 60000000
       refresh-token-expire-length: 1200000
 kakao_client_id: kakao_client_id
 kakao_client_secret: kakao_client_secret
@@ -34,8 +39,3 @@ aws:
     key: key
 uploader:
   image-url: https://image.donggle.blog/
-data:
-  web:
-    pageable:
-      default-page-size: 12
-      max-page-size: 100

--- a/backend/src/test/java/org/donggle/backend/application/service/ModifyWritingOrderTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/ModifyWritingOrderTest.java
@@ -421,392 +421,525 @@ class ModifyWritingOrderTest {
 
     @Nested
     @DisplayName("두 개의 카테고리에서 움직이는 경우")
-    class MovingInTwoCategoriesTest {
-        @Test
-        @DisplayName("[기본]['1', 2, 3, 4]/[추가][5, 6, 7, 8] -> [기본][2, 3, 4]/[추가]['1', 5, 6, 7, 8]")
-        void MovingInTwoCategories1() {
-            //when
-            writingService.modifyWritingOrder(
-                    member.getId(),
-                    basicWritings.get(0).getId(),
-                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(0).getId())
-            );
+    class movingInTwoCategoriesTest {
 
-            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
-            assertThat(basicCategoryWritings).hasSize(3);
-            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        @Nested
+        @DisplayName("비어 있는 카테고리로 글을 이동시키는 경우")
+        class MoveWritingIntoEmptyCategory {
+            private Category emptyCategory;
 
-            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
-            assertThat(anotherCategoryWritings).hasSize(5);
-            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+            @BeforeEach
+            void setUp() {
+                emptyCategory = categoryRepository.save(Category.of(new CategoryName("empty"), member));
+                anotherCategory.changeNextCategory(emptyCategory);
+            }
 
-            basicCategoryWritings.removeAll(basicNextWritings);
-            anotherCategoryWritings.removeAll(anotherNextWritings);
+            @Test
+            @DisplayName("[추가]['5', 6, 7, 8]/[empty][ ] -> [추가][6, 7, 8]/[empty]['5']")
+            void moveIntoEmptyCategory1() {
+                //given
+                writingService.modifyWritingOrder(
+                        member.getId(),
+                        anotherWritings.get(0).getId(),
+                        new WritingModifyRequest(null, emptyCategory.getId(), -1L)
+                );
 
-            //then
-            final Writing basic1Writing = basicCategoryWritings.get(0);
-            final Writing another1Writing = anotherCategoryWritings.get(0);
-            assertAll(
-                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(1)),
-                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+                //when
+                final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+                assertThat(anotherCategoryWritings).hasSize(3);
+                final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                        .map(Writing::getNextWriting)
+                        .toList();
 
-                    () -> assertThat(another1Writing).isEqualTo(basicWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
-            );
+                final List<Writing> emptyCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(emptyCategory.getId(), ACTIVE);
+                assertThat(emptyCategoryWritings).hasSize(1);
+                final List<Writing> emptyNextWritings = emptyCategoryWritings.stream()
+                        .map(Writing::getNextWriting)
+                        .toList();
+
+                anotherCategoryWritings.removeAll(anotherNextWritings);
+                emptyCategoryWritings.removeAll(emptyNextWritings);
+
+                //then
+                final Writing another1Writing = anotherCategoryWritings.get(0);
+                final Writing empty1Writing = emptyCategoryWritings.get(0);
+                assertAll(
+                        () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(1)),
+                        () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                        () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                        () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                        () -> assertThat(empty1Writing).isEqualTo(anotherWritings.get(0)),
+                        () -> assertThat(empty1Writing.getNextWriting()).isNull()
+                );
+            }
+
+            @Test
+            @DisplayName("[추가][5, '6', 7, 8]/[empty][ ] -> [추가][5, 7, 8]/[empty]['6']")
+            void moveIntoEmptyCategory2() {
+                //given
+                writingService.modifyWritingOrder(
+                        member.getId(),
+                        anotherWritings.get(1).getId(),
+                        new WritingModifyRequest(null, emptyCategory.getId(), -1L)
+                );
+
+                //when
+                final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+                assertThat(anotherCategoryWritings).hasSize(3);
+                final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                        .map(Writing::getNextWriting)
+                        .toList();
+
+                final List<Writing> emptyCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(emptyCategory.getId(), ACTIVE);
+                assertThat(emptyCategoryWritings).hasSize(1);
+                final List<Writing> emptyNextWritings = emptyCategoryWritings.stream()
+                        .map(Writing::getNextWriting)
+                        .toList();
+
+                anotherCategoryWritings.removeAll(anotherNextWritings);
+                emptyCategoryWritings.removeAll(emptyNextWritings);
+
+                //then
+                final Writing another1Writing = anotherCategoryWritings.get(0);
+                final Writing empty1Writing = emptyCategoryWritings.get(0);
+                assertAll(
+                        () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                        () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                        () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                        () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                        () -> assertThat(empty1Writing).isEqualTo(anotherWritings.get(1)),
+                        () -> assertThat(empty1Writing.getNextWriting()).isNull()
+                );
+            }
+
+            @Test
+            @DisplayName("[추가][5, 6, 7, '8']/[empty][ ] -> [추가][5, 6, 7]/[empty]['8']")
+            void moveIntoEmptyCategory3() {
+                //given
+                writingService.modifyWritingOrder(
+                        member.getId(),
+                        anotherWritings.get(3).getId(),
+                        new WritingModifyRequest(null, emptyCategory.getId(), -1L)
+                );
+
+                //when
+                final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+                assertThat(anotherCategoryWritings).hasSize(3);
+                final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                        .map(Writing::getNextWriting)
+                        .toList();
+
+                final List<Writing> emptyCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(emptyCategory.getId(), ACTIVE);
+                assertThat(emptyCategoryWritings).hasSize(1);
+                final List<Writing> emptyNextWritings = emptyCategoryWritings.stream()
+                        .map(Writing::getNextWriting)
+                        .toList();
+
+                anotherCategoryWritings.removeAll(anotherNextWritings);
+                emptyCategoryWritings.removeAll(emptyNextWritings);
+
+                //then
+                final Writing another1Writing = anotherCategoryWritings.get(0);
+                final Writing empty1Writing = emptyCategoryWritings.get(0);
+                assertAll(
+                        () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                        () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                        () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                        () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                        () -> assertThat(empty1Writing).isEqualTo(anotherWritings.get(3)),
+                        () -> assertThat(empty1Writing.getNextWriting()).isNull()
+                );
+            }
         }
+    }
 
-        @Test
-        @DisplayName("[기본]['1', 2, 3, 4]/[추가][5, 6, 7, 8] -> [기본][2, 3, 4]/[추가][5, '1', 6, 7, 8]")
-        void MovingInTwoCategories2() {
-            //when
-            writingService.modifyWritingOrder(
-                    member.getId(),
-                    basicWritings.get(0).getId(),
-                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(1).getId())
-            );
+    @Test
+    @DisplayName("[기본]['1', 2, 3, 4]/[추가][5, 6, 7, 8] -> [기본][2, 3, 4]/[추가]['1', 5, 6, 7, 8]")
+    void movingInTwoCategories1() {
+        //when
+        writingService.modifyWritingOrder(
+                member.getId(),
+                basicWritings.get(0).getId(),
+                new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(0).getId())
+        );
 
-            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
-            assertThat(basicCategoryWritings).hasSize(3);
-            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+        assertThat(basicCategoryWritings).hasSize(3);
+        final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
-            assertThat(anotherCategoryWritings).hasSize(5);
-            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+        assertThat(anotherCategoryWritings).hasSize(5);
+        final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            basicCategoryWritings.removeAll(basicNextWritings);
-            anotherCategoryWritings.removeAll(anotherNextWritings);
+        basicCategoryWritings.removeAll(basicNextWritings);
+        anotherCategoryWritings.removeAll(anotherNextWritings);
 
-            //then
-            final Writing basic1Writing = basicCategoryWritings.get(0);
-            final Writing another1Writing = anotherCategoryWritings.get(0);
-            assertAll(
-                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(1)),
-                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+        //then
+        final Writing basic1Writing = basicCategoryWritings.get(0);
+        final Writing another1Writing = anotherCategoryWritings.get(0);
+        assertAll(
+                () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(1)),
+                () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
 
-                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(basicWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
-            );
-        }
+                () -> assertThat(another1Writing).isEqualTo(basicWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+        );
+    }
 
-        @Test
-        @DisplayName("[기본]['1', 2, 3, 4]/[추가][5, 6, 7, 8] -> [기본][2, 3, 4]/[추가][5, 6, 7, 8, '1']")
-        void MovingInTwoCategories3() {
-            //when
-            writingService.modifyWritingOrder(
-                    member.getId(),
-                    basicWritings.get(0).getId(),
-                    new WritingModifyRequest(null, anotherCategory.getId(), -1L)
-            );
+    @Test
+    @DisplayName("[기본]['1', 2, 3, 4]/[추가][5, 6, 7, 8] -> [기본][2, 3, 4]/[추가][5, '1', 6, 7, 8]")
+    void movingInTwoCategories2() {
+        //when
+        writingService.modifyWritingOrder(
+                member.getId(),
+                basicWritings.get(0).getId(),
+                new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(1).getId())
+        );
 
-            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
-            assertThat(basicCategoryWritings).hasSize(3);
-            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+        assertThat(basicCategoryWritings).hasSize(3);
+        final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
-            assertThat(anotherCategoryWritings).hasSize(5);
-            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+        assertThat(anotherCategoryWritings).hasSize(5);
+        final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            basicCategoryWritings.removeAll(basicNextWritings);
-            anotherCategoryWritings.removeAll(anotherNextWritings);
+        basicCategoryWritings.removeAll(basicNextWritings);
+        anotherCategoryWritings.removeAll(anotherNextWritings);
 
-            //then
-            final Writing basic1Writing = basicCategoryWritings.get(0);
-            final Writing another1Writing = anotherCategoryWritings.get(0);
-            assertAll(
-                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(1)),
-                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+        //then
+        final Writing basic1Writing = basicCategoryWritings.get(0);
+        final Writing another1Writing = anotherCategoryWritings.get(0);
+        assertAll(
+                () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(1)),
+                () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
 
-                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
-            );
-        }
+                () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting()).isEqualTo(basicWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+        );
+    }
 
-        @Test
-        @DisplayName("[기본][1, '2', 3, 4]/[추가][5, 6, 7, 8] -> [기본][1, 3, 4]/[추가]['2', 5, 6, 7, 8]")
-        void MovingInTwoCategories4() {
-            //when
-            writingService.modifyWritingOrder(
-                    member.getId(),
-                    basicWritings.get(1).getId(),
-                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(0).getId())
-            );
+    @Test
+    @DisplayName("[기본]['1', 2, 3, 4]/[추가][5, 6, 7, 8] -> [기본][2, 3, 4]/[추가][5, 6, 7, 8, '1']")
+    void movingInTwoCategories3() {
+        //when
+        writingService.modifyWritingOrder(
+                member.getId(),
+                basicWritings.get(0).getId(),
+                new WritingModifyRequest(null, anotherCategory.getId(), -1L)
+        );
 
-            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
-            assertThat(basicCategoryWritings).hasSize(3);
-            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+        assertThat(basicCategoryWritings).hasSize(3);
+        final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
-            assertThat(anotherCategoryWritings).hasSize(5);
-            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+        assertThat(anotherCategoryWritings).hasSize(5);
+        final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            basicCategoryWritings.removeAll(basicNextWritings);
-            anotherCategoryWritings.removeAll(anotherNextWritings);
+        basicCategoryWritings.removeAll(basicNextWritings);
+        anotherCategoryWritings.removeAll(anotherNextWritings);
 
-            //then
-            final Writing basic1Writing = basicCategoryWritings.get(0);
-            final Writing another1Writing = anotherCategoryWritings.get(0);
-            assertAll(
-                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
-                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+        //then
+        final Writing basic1Writing = basicCategoryWritings.get(0);
+        final Writing another1Writing = anotherCategoryWritings.get(0);
+        assertAll(
+                () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(1)),
+                () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
 
-                    () -> assertThat(another1Writing).isEqualTo(basicWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
-            );
-        }
+                () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+        );
+    }
 
-        @Test
-        @DisplayName("[기본][1, '2', 3, 4]/[추가][5, 6, 7, 8] -> [기본][1, 3, 4]/[추가][5, 6, '2', 7, 8]")
-        void MovingInTwoCategories5() {
-            //when
-            writingService.modifyWritingOrder(
-                    member.getId(),
-                    basicWritings.get(1).getId(),
-                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(2).getId())
-            );
+    @Test
+    @DisplayName("[기본][1, '2', 3, 4]/[추가][5, 6, 7, 8] -> [기본][1, 3, 4]/[추가]['2', 5, 6, 7, 8]")
+    void movingInTwoCategories4() {
+        //when
+        writingService.modifyWritingOrder(
+                member.getId(),
+                basicWritings.get(1).getId(),
+                new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(0).getId())
+        );
 
-            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
-            assertThat(basicCategoryWritings).hasSize(3);
-            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+        assertThat(basicCategoryWritings).hasSize(3);
+        final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
-            assertThat(anotherCategoryWritings).hasSize(5);
-            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+        assertThat(anotherCategoryWritings).hasSize(5);
+        final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            basicCategoryWritings.removeAll(basicNextWritings);
-            anotherCategoryWritings.removeAll(anotherNextWritings);
+        basicCategoryWritings.removeAll(basicNextWritings);
+        anotherCategoryWritings.removeAll(anotherNextWritings);
 
-            //then
-            final Writing basic1Writing = basicCategoryWritings.get(0);
-            final Writing another1Writing = anotherCategoryWritings.get(0);
-            assertAll(
-                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
-                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+        //then
+        final Writing basic1Writing = basicCategoryWritings.get(0);
+        final Writing another1Writing = anotherCategoryWritings.get(0);
+        assertAll(
+                () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
 
-                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
-            );
-        }
+                () -> assertThat(another1Writing).isEqualTo(basicWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+        );
+    }
 
-        @Test
-        @DisplayName("[기본][1, '2', 3, 4]/[추가][5, 6, 7, 8] -> [기본][1, 3, 4]/[추가][5, 6, 7, 8, '2']")
-        void MovingInTwoCategories6() {
-            //when
-            writingService.modifyWritingOrder(
-                    member.getId(),
-                    basicWritings.get(1).getId(),
-                    new WritingModifyRequest(null, anotherCategory.getId(), -1L)
-            );
+    @Test
+    @DisplayName("[기본][1, '2', 3, 4]/[추가][5, 6, 7, 8] -> [기본][1, 3, 4]/[추가][5, 6, '2', 7, 8]")
+    void movingInTwoCategories5() {
+        //when
+        writingService.modifyWritingOrder(
+                member.getId(),
+                basicWritings.get(1).getId(),
+                new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(2).getId())
+        );
 
-            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
-            assertThat(basicCategoryWritings).hasSize(3);
-            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+        assertThat(basicCategoryWritings).hasSize(3);
+        final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
-            assertThat(anotherCategoryWritings).hasSize(5);
-            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+        assertThat(anotherCategoryWritings).hasSize(5);
+        final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            basicCategoryWritings.removeAll(basicNextWritings);
-            anotherCategoryWritings.removeAll(anotherNextWritings);
+        basicCategoryWritings.removeAll(basicNextWritings);
+        anotherCategoryWritings.removeAll(anotherNextWritings);
 
-            //then
-            final Writing basic1Writing = basicCategoryWritings.get(0);
-            final Writing another1Writing = anotherCategoryWritings.get(0);
-            assertAll(
-                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
-                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+        //then
+        final Writing basic1Writing = basicCategoryWritings.get(0);
+        final Writing another1Writing = anotherCategoryWritings.get(0);
+        assertAll(
+                () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
 
-                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
-            );
-        }
+                () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+        );
+    }
 
-        @Test
-        @DisplayName("[기본][1, 2, 3, '4']/[추가][5, 6, 7, 8] -> [기본][1, 2, 3]/[추가]['4', 5, 6, 7, 8]")
-        void MovingInTwoCategories7() {
-            //when
-            writingService.modifyWritingOrder(
-                    member.getId(),
-                    basicWritings.get(3).getId(),
-                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(0).getId())
-            );
+    @Test
+    @DisplayName("[기본][1, '2', 3, 4]/[추가][5, 6, 7, 8] -> [기본][1, 3, 4]/[추가][5, 6, 7, 8, '2']")
+    void movingInTwoCategories6() {
+        //when
+        writingService.modifyWritingOrder(
+                member.getId(),
+                basicWritings.get(1).getId(),
+                new WritingModifyRequest(null, anotherCategory.getId(), -1L)
+        );
 
-            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
-            assertThat(basicCategoryWritings).hasSize(3);
-            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+        assertThat(basicCategoryWritings).hasSize(3);
+        final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
-            assertThat(anotherCategoryWritings).hasSize(5);
-            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+        assertThat(anotherCategoryWritings).hasSize(5);
+        final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            basicCategoryWritings.removeAll(basicNextWritings);
-            anotherCategoryWritings.removeAll(anotherNextWritings);
+        basicCategoryWritings.removeAll(basicNextWritings);
+        anotherCategoryWritings.removeAll(anotherNextWritings);
 
-            //then
-            final Writing basic1Writing = basicCategoryWritings.get(0);
-            final Writing another1Writing = anotherCategoryWritings.get(0);
-            assertAll(
-                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
-                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(1)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+        //then
+        final Writing basic1Writing = basicCategoryWritings.get(0);
+        final Writing another1Writing = anotherCategoryWritings.get(0);
+        assertAll(
+                () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(2)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
 
-                    () -> assertThat(another1Writing).isEqualTo(basicWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
-            );
-        }
+                () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+        );
+    }
 
-        @Test
-        @DisplayName("[기본][1, 2, 3, '4']/[추가][5, 6, 7, 8] -> [기본][1, 2, 3]/[추가][5, 6, '4', 7, 8]")
-        void MovingInTwoCategories8() {
-            //when
-            writingService.modifyWritingOrder(
-                    member.getId(),
-                    basicWritings.get(3).getId(),
-                    new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(2).getId())
-            );
+    @Test
+    @DisplayName("[기본][1, 2, 3, '4']/[추가][5, 6, 7, 8] -> [기본][1, 2, 3]/[추가]['4', 5, 6, 7, 8]")
+    void movingInTwoCategories7() {
+        //when
+        writingService.modifyWritingOrder(
+                member.getId(),
+                basicWritings.get(3).getId(),
+                new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(0).getId())
+        );
 
-            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
-            assertThat(basicCategoryWritings).hasSize(3);
-            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+        assertThat(basicCategoryWritings).hasSize(3);
+        final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
-            assertThat(anotherCategoryWritings).hasSize(5);
-            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+        assertThat(anotherCategoryWritings).hasSize(5);
+        final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            basicCategoryWritings.removeAll(basicNextWritings);
-            anotherCategoryWritings.removeAll(anotherNextWritings);
+        basicCategoryWritings.removeAll(basicNextWritings);
+        anotherCategoryWritings.removeAll(anotherNextWritings);
 
-            //then
-            final Writing basic1Writing = basicCategoryWritings.get(0);
-            final Writing another1Writing = anotherCategoryWritings.get(0);
-            assertAll(
-                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
-                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(1)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+        //then
+        final Writing basic1Writing = basicCategoryWritings.get(0);
+        final Writing another1Writing = anotherCategoryWritings.get(0);
+        assertAll(
+                () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(1)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
 
-                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
-            );
-        }
+                () -> assertThat(another1Writing).isEqualTo(basicWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+        );
+    }
 
-        @Test
-        @DisplayName("[기본][1, 2, 3, '4']/[추가][5, 6, 7, 8] -> [기본][1, 2, 3]/[추가][5, 6, 7, 8, '4']")
-        void MovingInTwoCategories9() {
-            //when
-            writingService.modifyWritingOrder(
-                    member.getId(),
-                    basicWritings.get(3).getId(),
-                    new WritingModifyRequest(null, anotherCategory.getId(), -1L)
-            );
+    @Test
+    @DisplayName("[기본][1, 2, 3, '4']/[추가][5, 6, 7, 8] -> [기본][1, 2, 3]/[추가][5, 6, '4', 7, 8]")
+    void movingInTwoCategories8() {
+        //when
+        writingService.modifyWritingOrder(
+                member.getId(),
+                basicWritings.get(3).getId(),
+                new WritingModifyRequest(null, anotherCategory.getId(), anotherWritings.get(2).getId())
+        );
 
-            final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
-            assertThat(basicCategoryWritings).hasSize(3);
-            final List<Writing> basicNextWritings = basicCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+        assertThat(basicCategoryWritings).hasSize(3);
+        final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
-            assertThat(anotherCategoryWritings).hasSize(5);
-            final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
-                    .map(Writing::getNextWriting)
-                    .toList();
+        final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+        assertThat(anotherCategoryWritings).hasSize(5);
+        final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
 
-            basicCategoryWritings.removeAll(basicNextWritings);
-            anotherCategoryWritings.removeAll(anotherNextWritings);
+        basicCategoryWritings.removeAll(basicNextWritings);
+        anotherCategoryWritings.removeAll(anotherNextWritings);
 
-            //then
-            final Writing basic1Writing = basicCategoryWritings.get(0);
-            final Writing another1Writing = anotherCategoryWritings.get(0);
-            assertAll(
-                    () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
-                    () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(1)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
-                    () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+        //then
+        final Writing basic1Writing = basicCategoryWritings.get(0);
+        final Writing another1Writing = anotherCategoryWritings.get(0);
+        assertAll(
+                () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(1)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
 
-                    () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
-                    () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
-                    () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
-            );
-        }
+                () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+        );
+    }
+
+    @Test
+    @DisplayName("[기본][1, 2, 3, '4']/[추가][5, 6, 7, 8] -> [기본][1, 2, 3]/[추가][5, 6, 7, 8, '4']")
+    void movingInTwoCategories9() {
+        //when
+        writingService.modifyWritingOrder(
+                member.getId(),
+                basicWritings.get(3).getId(),
+                new WritingModifyRequest(null, anotherCategory.getId(), -1L)
+        );
+
+        final List<Writing> basicCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(basicCategory.getId(), ACTIVE);
+        assertThat(basicCategoryWritings).hasSize(3);
+        final List<Writing> basicNextWritings = basicCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
+
+        final List<Writing> anotherCategoryWritings = writingRepository.findAllByCategoryIdAndStatus(anotherCategory.getId(), ACTIVE);
+        assertThat(anotherCategoryWritings).hasSize(5);
+        final List<Writing> anotherNextWritings = anotherCategoryWritings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
+
+        basicCategoryWritings.removeAll(basicNextWritings);
+        anotherCategoryWritings.removeAll(anotherNextWritings);
+
+        //then
+        final Writing basic1Writing = basicCategoryWritings.get(0);
+        final Writing another1Writing = anotherCategoryWritings.get(0);
+        assertAll(
+                () -> assertThat(basic1Writing).isEqualTo(basicWritings.get(0)),
+                () -> assertThat(basic1Writing.getNextWriting()).isEqualTo(basicWritings.get(1)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(2)),
+                () -> assertThat(basic1Writing.getNextWriting().getNextWriting().getNextWriting()).isNull(),
+
+                () -> assertThat(another1Writing).isEqualTo(anotherWritings.get(0)),
+                () -> assertThat(another1Writing.getNextWriting()).isEqualTo(anotherWritings.get(1)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(2)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting()).isEqualTo(anotherWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isEqualTo(basicWritings.get(3)),
+                () -> assertThat(another1Writing.getNextWriting().getNextWriting().getNextWriting().getNextWriting().getNextWriting()).isNull()
+        );
     }
 }


### PR DESCRIPTION
### 🛠️ Issue

- close #483 

### ✅ Tasks
- 비어 있는 카테고리에 글을 이동하는 경우에 대한 처리 로직 추가
- 비어 있는 카테고리에 글을 이동하는 경우에 대한 테스트 케이스 추가
- 운영 환경에서 발생하는 참조 무결성 예외를 잡기 위해 flush() 호출 로직 추가
- 

### ⏰ Time Difference
- 3 -> 2

### 📝 Note
로컬 환경에서 프론트와 백의 애플리케이션을 띄워서 운영 환경에 조금 더 가깝게 테스트를 해봤습니다! dev 서버에서 한 번 더 확인해보면 좋을 것 같아요 ㅠㅠㅠ
