### PR TITLE
[FE] fix: 카테고리 이름이 길면 카테고리를 열 수 있는 버튼이 보이지 않는 현상 수정

### DIFF
--- a/frontend/src/components/@common/Accordion/AccordionTitle.tsx
+++ b/frontend/src/components/@common/Accordion/AccordionTitle.tsx
@@ -59,6 +59,7 @@ const S = {
     height: 2.2rem;
     padding: 0.4rem;
     border-radius: 4px;
+    flex-shrink: 0;
 
     &:hover {
       background-color: ${({ theme }) => theme.color.gray5};

--- a/frontend/src/components/Category/Category/Category.tsx
+++ b/frontend/src/components/Category/Category/Category.tsx
@@ -99,7 +99,7 @@ const S = {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    width: 100%;
+    width: 90%;
     height: 3.6rem;
     border-radius: 4px;
     font-size: 1.4rem;

--- a/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
+++ b/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
@@ -93,6 +93,7 @@ const S = {
     justify-content: space-between;
     align-items: center;
     padding-bottom: 2rem;
+    gap: 0.3rem;
   `,
   Title: styled.h1`
     font-size: 4rem;
@@ -102,6 +103,7 @@ const S = {
     display: flex;
     justify-content: center;
     align-items: center;
+    flex-shrink: 0;
     border-radius: 12px;
     padding: 1rem;
     background-color: ${({ theme }) => theme.color.gray4};


### PR DESCRIPTION
### 🛠️ Issue

- close #492 

### ✅ Tasks
- [x] 카테고리 이름이 길면 카테고리를 열 수 있는 버튼이 보이지 않는 현상 수정
- [x] 글 제목이 길어지면 글 제목 수정하기 버튼이 작아지는 현상 수정

### ⏰ Time Difference
- 0.5 -> 0.5

### 📝 Note

- 카테고리 이름이 길면 카테고리를 열 수 있는 버튼이 보이지 않는 현상 수정

| 전 | 후 |
| ------------ | ------------- |
| <img width="293" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/3dd848b8-fcae-4c97-9b72-cba9e8a8c36c"> | <img width="290" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/e81f510e-f7d6-4d35-bc12-a089c1be383d"> |

- 글 제목이 길어지면 글 제목 수정하기 버튼이 작아지는 현상 수정

| 전 | 후 |
| ------------ | ------------- |
| <img width="640" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/cb1c04f4-286a-4554-a027-bd4797b6c416"> | <img width="634" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/f9a3ba87-151f-48eb-9f85-2ed92ab6a213"> |
