### PR TITLE
[FE] fix: 발행정보와 발행 플랫폼 헤더와 데이터 위치 조정

### DIFF
--- a/frontend/src/components/WritingTable/WritingTable.tsx
+++ b/frontend/src/components/WritingTable/WritingTable.tsx
@@ -47,6 +47,7 @@ const WritingTable = ({ writings, categoryId }: Props) => {
             tabIndex={0}
           >
             <td>{title}</td>
+            <td>{dateFormatter(createdAt, 'YYYY.MM.DD.')}</td>
             <td>
               <S.PublishedToIconContainer>
                 {publishedDetails.map(({ blogName }, index) => (
@@ -54,7 +55,6 @@ const WritingTable = ({ writings, categoryId }: Props) => {
                 ))}
               </S.PublishedToIconContainer>
             </td>
-            <td>{dateFormatter(createdAt, 'YYYY.MM.DD.')}</td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
### 🛠️ Issue

- close #494

### ✅ Tasks
- [x] 테이블 헤더에 발행날짜와 발행 플랫폼 내용이 맞지 않는 현상 수정

### ⏰ Time Difference
- 0.1 -> 0.1

### 📝 Note
전체 글/카테고리 모두 생성날짜-발행한 플랫폼 순서로 바꿨습니다. 
이미지는 마지막으로 들어가는게 더 자연스러운 것 같아서 플랫폼을 마지막으로 뺐습니다!

<img width="977" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/d36751e6-ec52-41cf-b43e-0a8c5cdd9b8a">


<img width="990" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/8f771585-f285-478b-a2cf-d316f2ea7787">

