### PR TITLE
[FE] fix: 글에서 빈 블락이 렌더링되지 않는 현상 수정

### DIFF
--- a/frontend/src/components/WritingViewer/WritingViewer.tsx
+++ b/frontend/src/components/WritingViewer/WritingViewer.tsx
@@ -70,37 +70,37 @@ const S = {
     font-size: 1.6rem;
 
     h1 {
-      margin: 3.4rem 0 1.7rem;
+      padding: 3.4rem 0 1.7rem;
       font-size: 3.4rem;
     }
 
     h2 {
-      margin: 2.8rem 0 1.4rem;
+      padding: 2.8rem 0 1.4rem;
       font-size: 2.8rem;
     }
 
     h3 {
-      margin: 2.2rem 0 1.1rem;
+      padding: 2.2rem 0 1.1rem;
       font-size: 2.2rem;
     }
 
     h4 {
-      margin: 1.6rem 0 0.8rem;
+      padding: 1.6rem 0 0.8rem;
       font-size: 1.6rem;
     }
 
     h5 {
-      margin: 1.3rem 0 0.65rem;
+      padding: 1.3rem 0 0.65rem;
       font-size: 1.3rem;
     }
 
     h6 {
-      margin: 1rem 0 0.5rem;
+      padding: 1rem 0 0.5rem;
       font-size: 1rem;
     }
 
     p {
-      margin: 1.6rem 0;
+      padding: 1rem 0;
       font-size: 1.6rem;
     }
 
@@ -116,7 +116,6 @@ const S = {
     ol,
     ul {
       padding-left: 2rem;
-      margin: 1rem 0;
     }
 
     ul > li {
@@ -128,7 +127,7 @@ const S = {
     }
 
     li {
-      margin-bottom: 10px;
+      padding: 0.5rem 0;
     }
 
     a {

--- a/frontend/src/components/WritingViewer/WritingViewer.tsx
+++ b/frontend/src/components/WritingViewer/WritingViewer.tsx
@@ -102,6 +102,7 @@ const S = {
     p {
       padding: 1rem 0;
       font-size: 1.6rem;
+      line-height: 2.3rem;
     }
 
     blockquote {


### PR DESCRIPTION
### 🛠️ Issue

- close #496 

### ✅ Tasks
- [x] 글에서 빈 블락이 렌더링되지 않는 현상 수정
- [x] p태그의 행간 간격 더 넓게 조정

### ⏰ Time Difference
- 0.3 -> 0.3

### 📝 Note
| 전 | 후 | 노션 원본 |
| ------------ | ------------- | ------------- |
| <img width="511" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/3222be98-6537-4b69-8b13-e6ab1bf2937e"> | <img width="556" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/903ace5b-002f-4de2-a63f-7de066b2d814"> | <img width="559" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/5ad04c1d-af74-4208-901b-9fc5d1fb2c8e"> |

1. p태그 내에서 행간 크기가 너무 달라붙어 있어서 노션과 유사하게 좀더 넓게 조정했습니다.

2. `develop 브랜치와 머지 시 ~~~`, `사실 실제 API와의 테스트`로 시작하는 문장 위에 원래 한 줄 공백이 있는데 기존에는 공백이 무시되던 현상을 수정했습니다.

  원인은 원래 한 줄 공백이 빈 p태그로 오게 되는데(`<p></p>`) 이 경우 margin 겹침(상쇄) 현상 때문에 공백이 무시되고 있던 것이어서 margin을 padding으로 바꾸어 해결하였습니다.
<img width="1248" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/57815133/10577251-e198-4d38-95f4-41c3b5c23901">
