### PR TITLE
[BE] refactor: 회원 탈퇴 로직 수정

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/repository/BlockRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/BlockRepository.java
@@ -19,7 +19,7 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     List<NormalBlock> findNormalBlocks(@Param("blocks") List<Block> blocks);
 
     @Override
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("delete from Block b where b in :blocks")
     void deleteAll(@Param("blocks") final Iterable<? extends Block> blocks);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/BlockRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/BlockRepository.java
@@ -13,10 +13,10 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     @Query("""
             select b
             from Block b
-            where b in :blocks and
+            where b.id in :blockIds and
             type(b) = NormalBlock
             """)
-    List<NormalBlock> findNormalBlocks(@Param("blocks") List<Block> blocks);
+    List<NormalBlock> findNormalBlocks(@Param("blockIds") final List<Long> blockIds);
 
     @Override
     @Modifying

--- a/backend/src/main/java/org/donggle/backend/application/repository/BlockRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/BlockRepository.java
@@ -10,12 +10,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
-
-    @Override
-    @Modifying(flushAutomatically = true)
-    @Query("delete from Block b where b in :blocks")
-    void deleteAll(@Param("blocks") final Iterable<? extends Block> blocks);
-
     @Query("""
             select b
             from Block b
@@ -23,4 +17,9 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
             type(b) = NormalBlock
             """)
     List<NormalBlock> findNormalBlocks(@Param("blocks") List<Block> blocks);
+
+    @Override
+    @Modifying(flushAutomatically = true)
+    @Query("delete from Block b where b in :blocks")
+    void deleteAll(@Param("blocks") final Iterable<? extends Block> blocks);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/BlockRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/BlockRepository.java
@@ -11,15 +11,16 @@ import java.util.List;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
 
-    @Modifying
-    @Query("delete from Block b where b.id in :blockIds")
-    void deleteAllByIds(@Param("blockIds") List<Long> blockIds);
+    @Override
+    @Modifying(flushAutomatically = true)
+    @Query("delete from Block b where b in :blocks")
+    void deleteAll(@Param("blocks") final Iterable<? extends Block> blocks);
 
     @Query("""
             select b
             from Block b
-            where b.id in :blockIds and
+            where b in :blocks and
             type(b) = NormalBlock
             """)
-    List<NormalBlock> findNormalBlocksByIds(@Param("blockIds") List<Long> blockIds);
+    List<NormalBlock> findNormalBlocks(@Param("blocks") List<Block> blocks);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/BlockRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/BlockRepository.java
@@ -1,0 +1,25 @@
+package org.donggle.backend.application.repository;
+
+import org.donggle.backend.domain.writing.block.Block;
+import org.donggle.backend.domain.writing.block.NormalBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface BlockRepository extends JpaRepository<Block, Long> {
+
+    @Modifying
+    @Query("delete from Block b where b.id in :blockIds")
+    void deleteAllByIds(@Param("blockIds") List<Long> blockIds);
+
+    @Query("""
+            select b
+            from Block b
+            where b.id in :blockIds and
+            type(b) = NormalBlock
+            """)
+    List<NormalBlock> findNormalBlocksByIds(@Param("blockIds") List<Long> blockIds);
+}

--- a/backend/src/main/java/org/donggle/backend/application/repository/BlogWritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/BlogWritingRepository.java
@@ -3,6 +3,7 @@ package org.donggle.backend.application.repository;
 import org.donggle.backend.domain.blog.BlogWriting;
 import org.donggle.backend.domain.writing.Writing;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,6 +15,7 @@ public interface BlogWritingRepository extends JpaRepository<BlogWriting, Long> 
     @Query("SELECT bw FROM BlogWriting bw LEFT JOIN FETCH bw.blog WHERE bw.writing IN :writings")
     List<BlogWriting> findWithFetch(@Param("writings") List<Writing> writings);
 
-    @Query("select bw from BlogWriting bw where bw.writing in :writings")
-    List<BlogWriting> findAllByWritingIds(@Param("writings") List<Writing> writings);
+    @Modifying
+    @Query("delete from BlogWriting bw where bw.writing in :writings")
+    void deleteAllByWritings(@Param("writings") final List<Writing> writings);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/BlogWritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/BlogWritingRepository.java
@@ -15,7 +15,7 @@ public interface BlogWritingRepository extends JpaRepository<BlogWriting, Long> 
     @Query("SELECT bw FROM BlogWriting bw LEFT JOIN FETCH bw.blog WHERE bw.writing IN :writings")
     List<BlogWriting> findWithFetch(@Param("writings") List<Writing> writings);
 
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("delete from BlogWriting bw where bw.writing in :writings")
     void deleteAllByWritings(@Param("writings") final List<Writing> writings);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/BlogWritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/BlogWritingRepository.java
@@ -15,7 +15,7 @@ public interface BlogWritingRepository extends JpaRepository<BlogWriting, Long> 
     @Query("SELECT bw FROM BlogWriting bw LEFT JOIN FETCH bw.blog WHERE bw.writing IN :writings")
     List<BlogWriting> findWithFetch(@Param("writings") List<Writing> writings);
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("delete from BlogWriting bw where bw.writing in :writings")
     void deleteAllByWritings(@Param("writings") final List<Writing> writings);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/BlogWritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/BlogWritingRepository.java
@@ -13,4 +13,7 @@ public interface BlogWritingRepository extends JpaRepository<BlogWriting, Long> 
 
     @Query("SELECT bw FROM BlogWriting bw LEFT JOIN FETCH bw.blog WHERE bw.writing IN :writings")
     List<BlogWriting> findWithFetch(@Param("writings") List<Writing> writings);
+
+    @Query("select bw from BlogWriting bw where bw.writing in :writings")
+    List<BlogWriting> findAllByWritingIds(@Param("writings") List<Writing> writings);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/CategoryRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/CategoryRepository.java
@@ -29,7 +29,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByIdAndMemberId(final Long categoryId, final Long memberId);
 
     @Override
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("delete from Category c where c = :category")
     void delete(@Param("category") final Category category);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/CategoryRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/CategoryRepository.java
@@ -29,6 +29,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByIdAndMemberId(final Long categoryId, final Long memberId);
 
-    @Modifying
-    void deleteAllByMember(final Member member);
+    @Modifying(flushAutomatically = true)
+    @Query("delete from Category c where c.member = :member")
+    void deleteAllByMember(@Param("member") final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/CategoryRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/CategoryRepository.java
@@ -2,7 +2,9 @@ package org.donggle.backend.application.repository;
 
 import org.donggle.backend.domain.category.Category;
 import org.donggle.backend.domain.category.CategoryName;
+import org.donggle.backend.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -26,4 +28,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findPreCategoryByCategoryId(@Param("categoryId") final Long categoryId);
 
     Optional<Category> findByIdAndMemberId(final Long categoryId, final Long memberId);
+
+    @Modifying
+    void deleteAllByMember(final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/CategoryRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/CategoryRepository.java
@@ -2,7 +2,6 @@ package org.donggle.backend.application.repository;
 
 import org.donggle.backend.domain.category.Category;
 import org.donggle.backend.domain.category.CategoryName;
-import org.donggle.backend.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -29,7 +28,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByIdAndMemberId(final Long categoryId, final Long memberId);
 
+    @Override
     @Modifying(flushAutomatically = true)
-    @Query("delete from Category c where c.member = :member")
-    void deleteAllByMember(@Param("member") final Member member);
+    @Query("delete from Category c where c = :category")
+    void delete(@Param("category") final Category category);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/MemberCredentialsRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/MemberCredentialsRepository.java
@@ -13,7 +13,7 @@ public interface MemberCredentialsRepository extends JpaRepository<MemberCredent
 
     Optional<MemberCredentials> findByMember(Member member);
 
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("delete from MemberCredentials mc where mc.member = :member")
     void deleteByMember(@Param("member") final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/MemberCredentialsRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/MemberCredentialsRepository.java
@@ -4,6 +4,8 @@ import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.member.MemberCredentials;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -11,6 +13,7 @@ public interface MemberCredentialsRepository extends JpaRepository<MemberCredent
 
     Optional<MemberCredentials> findByMember(Member member);
 
-    @Modifying
-    void deleteByMember(final Member member);
+    @Modifying(flushAutomatically = true)
+    @Query("delete from MemberCredentials mc where mc.member = :member")
+    void deleteByMember(@Param("member") final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/MemberCredentialsRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/MemberCredentialsRepository.java
@@ -3,10 +3,14 @@ package org.donggle.backend.application.repository;
 import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.member.MemberCredentials;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 import java.util.Optional;
 
 public interface MemberCredentialsRepository extends JpaRepository<MemberCredentials, Long> {
 
     Optional<MemberCredentials> findByMember(Member member);
+
+    @Modifying
+    void deleteByMember(final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/MemberCredentialsRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/MemberCredentialsRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 public interface MemberCredentialsRepository extends JpaRepository<MemberCredentials, Long> {
 
-    Optional<MemberCredentials> findMemberCredentialsByMember(Member member);
+    Optional<MemberCredentials> findByMember(Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/MemberRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/MemberRepository.java
@@ -3,9 +3,17 @@ package org.donggle.backend.application.repository;
 import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.oauth.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialIdAndSocialType(final Long socialId, final SocialType socialType);
+
+    @Override
+    @Modifying(flushAutomatically = true)
+    @Query("delete from Member m where m = :member")
+    void delete(@Param("member") final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/MemberRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/MemberRepository.java
@@ -13,7 +13,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialIdAndSocialType(final Long socialId, final SocialType socialType);
 
     @Override
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("delete from Member m where m = :member")
     void delete(@Param("member") final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/StyleRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/StyleRepository.java
@@ -6,11 +6,9 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface StyleRepository extends JpaRepository<Style, Long> {
-
-    @Modifying
-    @Query("delete from Style s where s.id in :styleIds")
-    void deleteAllByIds(@Param("styleIds") final List<Long> styleIds);
+    @Override
+    @Modifying(flushAutomatically = true)
+    @Query("delete from Style s where s in :styles")
+    void deleteAll(@Param("styles") final Iterable<? extends Style> styles);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/StyleRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/StyleRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface StyleRepository extends JpaRepository<Style, Long> {
     @Override
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("delete from Style s where s.id in :styleIds")
     void deleteAllById(@Param("styleIds") final Iterable<? extends Long> styleIds);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/StyleRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/StyleRepository.java
@@ -9,6 +9,6 @@ import org.springframework.data.repository.query.Param;
 public interface StyleRepository extends JpaRepository<Style, Long> {
     @Override
     @Modifying(flushAutomatically = true)
-    @Query("delete from Style s where s in :styles")
-    void deleteAll(@Param("styles") final Iterable<? extends Style> styles);
+    @Query("delete from Style s where s.id in :styleIds")
+    void deleteAllById(@Param("styleIds") final Iterable<? extends Long> styleIds);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/StyleRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/StyleRepository.java
@@ -2,6 +2,15 @@ package org.donggle.backend.application.repository;
 
 import org.donggle.backend.domain.writing.Style;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface StyleRepository extends JpaRepository<Style, Long> {
+
+    @Modifying
+    @Query("delete from Style s where s.id in :styleIds")
+    void deleteAllByIds(@Param("styleIds") final List<Long> styleIds);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/TokenRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/TokenRepository.java
@@ -16,7 +16,7 @@ public interface TokenRepository extends JpaRepository<RefreshToken, Long> {
     @Query("delete from RefreshToken rt where rt.member.id = :memberId")
     void deleteByMemberId(@Param("memberId") final Long memberId);
 
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("delete from RefreshToken rt where rt.member = :member")
     void deleteByMember(@Param("member") final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/TokenRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/TokenRepository.java
@@ -1,12 +1,22 @@
 package org.donggle.backend.application.repository;
 
 import org.donggle.backend.domain.auth.RefreshToken;
+import org.donggle.backend.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface TokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByMemberId(final Long memberId);
 
-    void deleteByMemberId(Long memberId);
+    @Modifying
+    @Query("delete from RefreshToken rt where rt.member.id = :memberId")
+    void deleteByMemberId(@Param("memberId") final Long memberId);
+
+    @Modifying(flushAutomatically = true)
+    @Query("delete from RefreshToken rt where rt.member = :member")
+    void deleteByMember(@Param("member") final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -99,8 +99,7 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
 
     List<Writing> findAllByMember(final Member member);
 
-    @Override
     @Modifying
     @Query("delete from Writing w where w = :writing")
-    void delete(@Param("writing") final Writing writing);
+    void deleteImmediately(@Param("writing") final Writing writing);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -6,7 +6,6 @@ import org.donggle.backend.domain.writing.WritingStatus;
 import org.donggle.backend.domain.writing.block.NormalBlock;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -98,14 +97,9 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
 
     Optional<Writing> findByIdAndStatus(final Long id, final WritingStatus status);
 
-    @EntityGraph(attributePaths = {"blocks"})
     List<Writing> findAllByMember(final Member member);
 
-    @Modifying
-    @Query(value = """
-            delete from writing
-            where member_id in :memberIds
-            """,
-            nativeQuery = true)
-    void deleteAllByMember(@Param("memberIds") final List<Long> memberIds);
+    @Modifying(flushAutomatically = true)
+    @Query("delete from Writing w where w.member = :member")
+    void deleteAllByMember(@Param("member") final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -100,7 +100,7 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
     List<Writing> findAllByMember(final Member member);
 
     @Override
-    @Modifying(flushAutomatically = true)
+    @Modifying
     @Query("delete from Writing w where w = :writing")
     void delete(@Param("writing") final Writing writing);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -6,7 +6,9 @@ import org.donggle.backend.domain.writing.WritingStatus;
 import org.donggle.backend.domain.writing.block.NormalBlock;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -96,5 +98,14 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
 
     Optional<Writing> findByIdAndStatus(final Long id, final WritingStatus status);
 
-    List<Writing> findByMember(final Member member);
+    @EntityGraph(attributePaths = {"blocks"})
+    List<Writing> findAllByMember(final Member member);
+
+    @Modifying
+    @Query(value = """
+            delete from writing
+            where member_id in :memberIds
+            """,
+            nativeQuery = true)
+    void deleteAllByMember(@Param("memberIds") final List<Long> memberIds);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -1,5 +1,6 @@
 package org.donggle.backend.application.repository;
 
+import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.writing.Writing;
 import org.donggle.backend.domain.writing.WritingStatus;
 import org.donggle.backend.domain.writing.block.NormalBlock;
@@ -94,4 +95,6 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
     Page<Writing> findByMemberIdAndWritingStatusOrderByCreatedAtDesc(@Param("memberId") final Long memberId, final Pageable pageable);
 
     Optional<Writing> findByIdAndStatus(final Long id, final WritingStatus status);
+
+    List<Writing> findByMember(final Member member);
 }

--- a/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
+++ b/backend/src/main/java/org/donggle/backend/application/repository/WritingRepository.java
@@ -99,7 +99,8 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
 
     List<Writing> findAllByMember(final Member member);
 
+    @Override
     @Modifying(flushAutomatically = true)
-    @Query("delete from Writing w where w.member = :member")
-    void deleteAllByMember(@Param("member") final Member member);
+    @Query("delete from Writing w where w = :writing")
+    void delete(@Param("writing") final Writing writing);
 }

--- a/backend/src/main/java/org/donggle/backend/application/service/blog/PublishService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/blog/PublishService.java
@@ -76,7 +76,7 @@ public class PublishService {
 
 
     private MemberCredentials findMemberCredentials(final Member member) {
-        return memberCredentialsRepository.findMemberCredentialsByMember(member)
+        return memberCredentialsRepository.findByMember(member)
                 .orElseThrow(NoSuchElementException::new);
     }
 

--- a/backend/src/main/java/org/donggle/backend/application/service/category/CategoryService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/category/CategoryService.java
@@ -72,8 +72,7 @@ public class CategoryService {
 
     @Transactional(readOnly = true)
     public CategoryListResponse findAll(final Long memberId) {
-        final Member findMember = findMember(memberId);
-        final List<Category> categories = categoryRepository.findAllByMemberId(findMember.getId());
+        final List<Category> categories = categoryRepository.findAllByMemberId(memberId);
         final List<Category> sortedCategories = sortCategory(categories, findBasicCategory(categories));
         final List<CategoryResponse> categoryResponses = sortedCategories.stream()
                 .map(CategoryResponse::of)

--- a/backend/src/main/java/org/donggle/backend/application/service/member/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/member/MemberService.java
@@ -54,9 +54,9 @@ public class MemberService {
 
     private void deleteWritings(final Member member) {
         final List<Writing> writings = writingRepository.findAllByMember(member);
+        blogWritingRepository.deleteAllByWritings(writings);
         writings.forEach(this::deleteBlocks);
         writingRepository.deleteAllByMember(member);
-        blogWritingRepository.deleteAllByWritings(writings);
     }
 
     private void deleteBlocks(final Writing writing) {

--- a/backend/src/main/java/org/donggle/backend/application/service/member/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/member/MemberService.java
@@ -1,15 +1,23 @@
 package org.donggle.backend.application.service.member;
 
 import lombok.RequiredArgsConstructor;
+import org.donggle.backend.application.repository.BlogWritingRepository;
+import org.donggle.backend.application.repository.CategoryRepository;
 import org.donggle.backend.application.repository.MemberCredentialsRepository;
 import org.donggle.backend.application.repository.MemberRepository;
+import org.donggle.backend.application.repository.TokenRepository;
+import org.donggle.backend.application.repository.WritingRepository;
+import org.donggle.backend.domain.blog.BlogWriting;
+import org.donggle.backend.domain.category.Category;
 import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.member.MemberCredentials;
+import org.donggle.backend.domain.writing.Writing;
 import org.donggle.backend.exception.notfound.MemberNotFoundException;
 import org.donggle.backend.ui.response.MemberPageResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -18,18 +26,50 @@ import java.util.NoSuchElementException;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberCredentialsRepository memberCredentialsRepository;
+    private final WritingRepository writingRepository;
+    private final BlogWritingRepository blogWritingRepository;
+    private final CategoryRepository categoryRepository;
+    private final TokenRepository tokenRepository;
 
     @Transactional(readOnly = true)
     public MemberPageResponse findMemberPage(final Long memberId) {
         final Member member = findMember(memberId);
-        final MemberCredentials memberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(member)
+        final MemberCredentials memberCredentials = memberCredentialsRepository.findByMember(member)
                 .orElseThrow(NoSuchElementException::new);
         return MemberPageResponse.of(member, memberCredentials);
     }
 
     public void deleteMember(final Long memberId) {
         final Member member = findMember(memberId);
+        deleteWritings(member);
+        deleteCategories(member);
+        deleteToken(member);
+        deleteMemberCredentials(member);
+
         memberRepository.delete(member);
+    }
+
+    private void deleteWritings(final Member member) {
+        final List<Writing> writings = writingRepository.findByMember(member);
+        final List<BlogWriting> blogWritings = blogWritingRepository.findAllByWritingIds(writings);
+
+        writingRepository.deleteAll(writings);
+        blogWritingRepository.deleteAll(blogWritings);
+    }
+
+    private void deleteMemberCredentials(final Member member) {
+        memberCredentialsRepository.findByMember(member)
+                .ifPresent(memberCredentialsRepository::delete);
+    }
+
+    private void deleteCategories(final Member member) {
+        final List<Category> categories = categoryRepository.findAllByMemberId(member.getId());
+        categoryRepository.deleteAll(categories);
+    }
+
+    private void deleteToken(final Member member) {
+        tokenRepository.findByMemberId(member.getId())
+                .ifPresent(tokenRepository::delete);
     }
 
     private Member findMember(final Long memberId) {

--- a/backend/src/main/java/org/donggle/backend/application/service/member/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/member/MemberService.java
@@ -83,7 +83,7 @@ public class MemberService {
             Writing target = writing;
             while (target != null) {
                 blockRepository.deleteAll(target.getBlocks());
-                writingRepository.delete(target);
+                writingRepository.deleteImmediately(target);
                 target = target.getNextWriting();
             }
         });

--- a/backend/src/main/java/org/donggle/backend/application/service/member/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/member/MemberService.java
@@ -14,13 +14,13 @@ import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.member.MemberCredentials;
 import org.donggle.backend.domain.writing.Style;
 import org.donggle.backend.domain.writing.Writing;
+import org.donggle.backend.domain.writing.block.Block;
 import org.donggle.backend.domain.writing.block.NormalBlock;
 import org.donggle.backend.exception.notfound.MemberNotFoundException;
 import org.donggle.backend.ui.response.MemberPageResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -62,16 +62,17 @@ public class MemberService {
     }
 
     private void deleteStyles(final List<Writing> writings) {
-        final List<Long> totalStyleIds = new ArrayList<>();
-        writings.forEach(writing -> {
-            final List<NormalBlock> normalBlocks = blockRepository.findNormalBlocks(writing.getBlocks());
-            final List<Long> styleIds = normalBlocks.stream()
-                    .flatMap(block -> block.getStyles().stream())
-                    .map(Style::getId)
-                    .toList();
-            totalStyleIds.addAll(styleIds);
-        });
-        styleRepository.deleteAllById(totalStyleIds);
+        final List<Long> blockIds = writings.stream()
+                .flatMap(writing -> writing.getBlocks().stream().map(Block::getId))
+                .toList();
+
+        final List<NormalBlock> normalBlocks = blockRepository.findNormalBlocks(blockIds);
+
+        final List<Long> styleIds = normalBlocks.stream()
+                .flatMap(block -> block.getStyles().stream().map(Style::getId))
+                .toList();
+
+        styleRepository.deleteAllById(styleIds);
     }
 
     private void deleteWritings(final List<Writing> writings) {

--- a/backend/src/main/java/org/donggle/backend/application/service/member/MemberService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/member/MemberService.java
@@ -9,16 +9,18 @@ import org.donggle.backend.application.repository.MemberRepository;
 import org.donggle.backend.application.repository.StyleRepository;
 import org.donggle.backend.application.repository.TokenRepository;
 import org.donggle.backend.application.repository.WritingRepository;
+import org.donggle.backend.domain.category.Category;
 import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.member.MemberCredentials;
+import org.donggle.backend.domain.writing.Style;
 import org.donggle.backend.domain.writing.Writing;
-import org.donggle.backend.domain.writing.block.Block;
 import org.donggle.backend.domain.writing.block.NormalBlock;
 import org.donggle.backend.exception.notfound.MemberNotFoundException;
 import org.donggle.backend.ui.response.MemberPageResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -45,29 +47,67 @@ public class MemberService {
 
     public void deleteMember(final Long memberId) {
         final Member member = findMember(memberId);
-        deleteWritings(member);
-        categoryRepository.deleteAllByMember(member);
-        tokenRepository.deleteByMember(member);
-        memberCredentialsRepository.deleteByMember(member);
-        memberRepository.delete(member);
-    }
-
-    private void deleteWritings(final Member member) {
         final List<Writing> writings = writingRepository.findAllByMember(member);
+        deleteBlogWritings(writings);
+        deleteStyles(writings);
+        deleteWritings(writings);
+        deleteCategories(member);
+        deleteToken(member);
+        deleteMemberCredentials(member);
+        deleteMember(member);
+    }
+
+    private void deleteBlogWritings(final List<Writing> writings) {
         blogWritingRepository.deleteAllByWritings(writings);
-        writings.forEach(this::deleteBlocks);
-        writingRepository.deleteAllByMember(member);
     }
 
-    private void deleteBlocks(final Writing writing) {
-        final List<Block> blocks = writing.getBlocks();
-        deleteStyles(blocks);
-        blockRepository.deleteAll(blocks);
+    private void deleteStyles(final List<Writing> writings) {
+        final List<Long> totalStyleIds = new ArrayList<>();
+        writings.forEach(writing -> {
+            final List<NormalBlock> normalBlocks = blockRepository.findNormalBlocks(writing.getBlocks());
+            final List<Long> styleIds = normalBlocks.stream()
+                    .flatMap(block -> block.getStyles().stream())
+                    .map(Style::getId)
+                    .toList();
+            totalStyleIds.addAll(styleIds);
+        });
+        styleRepository.deleteAllById(totalStyleIds);
     }
 
-    private void deleteStyles(final List<Block> blocks) {
-        final List<NormalBlock> normalBlocks = blockRepository.findNormalBlocks(blocks);
-        normalBlocks.forEach(normalBlock -> styleRepository.deleteAll(normalBlock.getStyles()));
+    private void deleteWritings(final List<Writing> writings) {
+        final List<Writing> nextWritings = writings.stream()
+                .map(Writing::getNextWriting)
+                .toList();
+        writings.removeAll(nextWritings);
+        writings.forEach(writing -> {
+            Writing target = writing;
+            while (target != null) {
+                blockRepository.deleteAll(target.getBlocks());
+                writingRepository.delete(target);
+                target = target.getNextWriting();
+            }
+        });
+    }
+
+    private void deleteCategories(final Member member) {
+        final List<Category> categories = categoryRepository.findAllByMemberId(member.getId());
+        Category target = categories.get(0);
+        while (target != null) {
+            categoryRepository.delete(target);
+            target = target.getNextCategory();
+        }
+    }
+
+    private void deleteToken(final Member member) {
+        tokenRepository.deleteByMember(member);
+    }
+
+    private void deleteMemberCredentials(final Member member) {
+        memberCredentialsRepository.deleteByMember(member);
+    }
+
+    private void deleteMember(final Member member) {
+        memberRepository.delete(member);
     }
 
     private Member findMember(final Long memberId) {

--- a/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/writing/WritingService.java
@@ -77,7 +77,7 @@ public class WritingService {
     public MemberCategoryNotionInfo getMemberCategoryNotionInfo(final Long memberId, final Long categoryId) {
         final Member findMember = findMember(memberId);
         final Category category = findCategory(memberId, categoryId);
-        final MemberCredentials memberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(findMember).orElseThrow();
+        final MemberCredentials memberCredentials = memberCredentialsRepository.findByMember(findMember).orElseThrow();
         final String notionToken = memberCredentials.getNotionToken().orElseThrow(NotionNotConnectedException::new);
         return new MemberCategoryNotionInfo(findMember, category, notionToken);
     }

--- a/backend/src/main/java/org/donggle/backend/domain/member/Member.java
+++ b/backend/src/main/java/org/donggle/backend/domain/member/Member.java
@@ -15,20 +15,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.donggle.backend.domain.BaseEntity;
 import org.donggle.backend.domain.oauth.SocialType;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE member SET is_deleted = true, deleted_at = now() WHERE id = ?")
-@Where(clause = "is_deleted = false")
-@Table(uniqueConstraints = {
-        @UniqueConstraint(name = "SOCIAL_ID_TYPE_UNIQUE", columnNames = {"socialId", "socialType"})
-})
+@Table(uniqueConstraints = @UniqueConstraint(name = "SOCIAL_ID_TYPE_UNIQUE", columnNames = {"socialId", "socialType"}))
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,8 +32,6 @@ public class Member extends BaseEntity {
     private Long socialId;
     @Enumerated(value = EnumType.STRING)
     private SocialType socialType;
-    private final boolean isDeleted = false;
-    private LocalDateTime deletedAt;
 
     private Member(final MemberName memberName, final Long socialId, final SocialType socialType) {
         this.memberName = memberName;

--- a/backend/src/main/java/org/donggle/backend/domain/writing/Writing.java
+++ b/backend/src/main/java/org/donggle/backend/domain/writing/Writing.java
@@ -45,7 +45,7 @@ public class Writing extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToMany(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "writing_id", nullable = false, updatable = false)
     private List<Block> blocks = new ArrayList<>();
     @OneToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/org/donggle/backend/domain/writing/Writing.java
+++ b/backend/src/main/java/org/donggle/backend/domain/writing/Writing.java
@@ -45,7 +45,7 @@ public class Writing extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
-    @OneToMany(cascade = CascadeType.PERSIST)
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @JoinColumn(name = "writing_id", nullable = false, updatable = false)
     private List<Block> blocks = new ArrayList<>();
     @OneToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/org/donggle/backend/domain/writing/block/NormalBlock.java
+++ b/backend/src/main/java/org/donggle/backend/domain/writing/block/NormalBlock.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class NormalBlock extends Block {
     @NotNull
     private RawText rawText;
-    @OneToMany(cascade = CascadeType.PERSIST)
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @JoinColumn(name = "normal_block_id", updatable = false, nullable = false)
     private List<Style> styles = new ArrayList<>();
 

--- a/backend/src/main/java/org/donggle/backend/domain/writing/block/NormalBlock.java
+++ b/backend/src/main/java/org/donggle/backend/domain/writing/block/NormalBlock.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class NormalBlock extends Block {
     @NotNull
     private RawText rawText;
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToMany(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "normal_block_id", updatable = false, nullable = false)
     private List<Style> styles = new ArrayList<>();
 

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/medium/MediumConnectionClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/medium/MediumConnectionClient.java
@@ -3,11 +3,11 @@ package org.donggle.backend.infrastructure.client.medium;
 import org.donggle.backend.application.repository.MemberCredentialsRepository;
 import org.donggle.backend.application.repository.MemberRepository;
 import org.donggle.backend.application.service.request.TokenAddRequest;
-import org.donggle.backend.infrastructure.client.exception.ClientException;
-import org.donggle.backend.infrastructure.client.exception.ClientInvalidTokenException;
 import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.member.MemberCredentials;
 import org.donggle.backend.exception.notfound.MemberNotFoundException;
+import org.donggle.backend.infrastructure.client.exception.ClientException;
+import org.donggle.backend.infrastructure.client.exception.ClientInvalidTokenException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -67,7 +67,7 @@ public class MediumConnectionClient {
     }
 
     private MemberCredentials findMemberCredentials(final Member member) {
-        return memberCredentialsRepository.findMemberCredentialsByMember(member)
+        return memberCredentialsRepository.findByMember(member)
                 .orElseThrow(NoSuchElementException::new);
     }
 

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/notion/NotionConnectionClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/notion/NotionConnectionClient.java
@@ -2,13 +2,13 @@ package org.donggle.backend.infrastructure.client.notion;
 
 import org.donggle.backend.application.repository.MemberCredentialsRepository;
 import org.donggle.backend.application.repository.MemberRepository;
-import org.donggle.backend.infrastructure.client.notion.dto.request.NotionTokenRequest;
-import org.donggle.backend.infrastructure.client.notion.dto.response.NotionTokenResponse;
 import org.donggle.backend.application.service.request.OAuthAccessTokenRequest;
-import org.donggle.backend.infrastructure.client.exception.ClientException;
 import org.donggle.backend.domain.member.Member;
 import org.donggle.backend.domain.member.MemberCredentials;
 import org.donggle.backend.exception.notfound.MemberNotFoundException;
+import org.donggle.backend.infrastructure.client.exception.ClientException;
+import org.donggle.backend.infrastructure.client.notion.dto.request.NotionTokenRequest;
+import org.donggle.backend.infrastructure.client.notion.dto.response.NotionTokenResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -93,7 +93,7 @@ public class NotionConnectionClient {
     }
 
     private MemberCredentials findMemberCredentials(final Member member) {
-        return memberCredentialsRepository.findMemberCredentialsByMember(member)
+        return memberCredentialsRepository.findByMember(member)
                 .orElseThrow(NoSuchElementException::new);
     }
 }

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
@@ -135,7 +135,7 @@ public class TistoryApiClient implements BlogClient {
     private MemberCredentials getMemberCredentials(final Long memberId) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
-        final MemberCredentials memberCredentials = memberCredentialsRepository.findMemberCredentialsByMember(member)
+        final MemberCredentials memberCredentials = memberCredentialsRepository.findByMember(member)
                 .orElseThrow(NoSuchElementException::new);
         if (!memberCredentials.isTistoryConnected()) {
             throw new TistoryNotConnectedException();

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryConnectionClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryConnectionClient.java
@@ -101,7 +101,7 @@ public class TistoryConnectionClient {
     }
 
     private MemberCredentials findMemberCredentials(final Member member) {
-        return memberCredentialsRepository.findMemberCredentialsByMember(member)
+        return memberCredentialsRepository.findByMember(member)
                 .orElseThrow(NoSuchElementException::new);
     }
 }

--- a/backend/src/main/java/org/donggle/backend/ui/MemberController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/MemberController.java
@@ -5,8 +5,8 @@ import org.donggle.backend.application.service.member.MemberService;
 import org.donggle.backend.ui.common.AuthenticationPrincipal;
 import org.donggle.backend.ui.response.MemberPageResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,8 +22,7 @@ public class MemberController {
         return ResponseEntity.ok(memberPage);
     }
 
-    // TODO : 이제 바로 삭제를 하니까, Http method를 DELETE로 하도록 하는 것이 어떨까?
-    @PostMapping("/delete")
+    @DeleteMapping
     public ResponseEntity<Void> deleteMember(@AuthenticationPrincipal final Long memberId) {
         memberService.deleteMember(memberId);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/org/donggle/backend/ui/MemberController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/MemberController.java
@@ -22,6 +22,7 @@ public class MemberController {
         return ResponseEntity.ok(memberPage);
     }
 
+    // TODO : 이제 바로 삭제를 하니까, Http method를 DELETE로 하도록 하는 것이 어떨까?
     @PostMapping("/delete")
     public ResponseEntity<Void> deleteMember(@AuthenticationPrincipal final Long memberId) {
         memberService.deleteMember(memberId);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        default_batch_fetch_size: 1000
     hibernate:
       ddl-auto: create
     show-sql: true

--- a/backend/src/test/java/org/donggle/backend/TestFixtures.java
+++ b/backend/src/test/java/org/donggle/backend/TestFixtures.java
@@ -84,5 +84,4 @@ public class TestFixtures {
                     )
             )
     );
-
 }

--- a/backend/src/test/java/org/donggle/backend/TestFixtures.java
+++ b/backend/src/test/java/org/donggle/backend/TestFixtures.java
@@ -1,0 +1,88 @@
+package org.donggle.backend;
+
+import org.donggle.backend.domain.auth.RefreshToken;
+import org.donggle.backend.domain.category.Category;
+import org.donggle.backend.domain.category.CategoryName;
+import org.donggle.backend.domain.member.Member;
+import org.donggle.backend.domain.member.MemberCredentials;
+import org.donggle.backend.domain.member.MemberName;
+import org.donggle.backend.domain.oauth.SocialType;
+import org.donggle.backend.domain.writing.BlockType;
+import org.donggle.backend.domain.writing.Style;
+import org.donggle.backend.domain.writing.StyleRange;
+import org.donggle.backend.domain.writing.StyleType;
+import org.donggle.backend.domain.writing.Title;
+import org.donggle.backend.domain.writing.Writing;
+import org.donggle.backend.domain.writing.block.CodeBlock;
+import org.donggle.backend.domain.writing.block.Depth;
+import org.donggle.backend.domain.writing.block.HorizontalRulesBlock;
+import org.donggle.backend.domain.writing.block.ImageBlock;
+import org.donggle.backend.domain.writing.block.ImageCaption;
+import org.donggle.backend.domain.writing.block.ImageUrl;
+import org.donggle.backend.domain.writing.block.Language;
+import org.donggle.backend.domain.writing.block.NormalBlock;
+import org.donggle.backend.domain.writing.block.RawText;
+
+import java.util.List;
+
+public class TestFixtures {
+    public static final Member MEMBER = Member.of(
+            new MemberName("테스트 멤버"),
+            1234L,
+            SocialType.KAKAO
+    );
+
+    public static final MemberCredentials MEMBER_CREDENTIALS = MemberCredentials.basic(MEMBER);
+
+    public static final RefreshToken REFRESH_TOKEN = new RefreshToken("testRefreshToken", MEMBER);
+
+    public static final Category BASIC_CATEGORY = Category.of(new CategoryName("기본"), MEMBER);
+
+    public static final Writing WRITING_WITH_NORMAL_BLOCK = Writing.of(MEMBER, new Title("WRITING_WITH_NORMAL_BLOCK"),
+            BASIC_CATEGORY,
+            List.of(
+                    new NormalBlock(
+                            Depth.from(1),
+                            BlockType.PARAGRAPH,
+                            RawText.from("테스트 글입니다"),
+                            List.of(
+                                    new Style(new StyleRange(0, 2), StyleType.BOLD),
+                                    new Style(new StyleRange(3, 4), StyleType.ITALIC)
+                            )
+                    )
+            )
+    );
+
+    public static final Writing GENERAL_WRITING = Writing.of(MEMBER, new Title("GENERAL_WRITING"),
+            BASIC_CATEGORY,
+            List.of(
+                    new NormalBlock(
+                            Depth.from(1),
+                            BlockType.PARAGRAPH,
+                            RawText.from("테스트 글입니다"),
+                            List.of(
+                                    new Style(new StyleRange(0, 2), StyleType.BOLD),
+                                    new Style(new StyleRange(3, 4), StyleType.ITALIC)
+                            )
+                    ),
+                    new CodeBlock(
+                            Depth.from(1),
+                            BlockType.CODE_BLOCK,
+                            RawText.from("public static void main(String... args) {}"),
+                            Language.from("java")
+                    ),
+                    new ImageBlock(
+                            Depth.from(1),
+                            BlockType.IMAGE,
+                            new ImageUrl("localhost:8080/hello-world.png"),
+                            new ImageCaption("테스트 이미지")
+                    ),
+                    new HorizontalRulesBlock(
+                            Depth.from(1),
+                            BlockType.HORIZONTAL_RULES,
+                            RawText.from("")
+                    )
+            )
+    );
+
+}

--- a/backend/src/test/java/org/donggle/backend/TestFixtures.java
+++ b/backend/src/test/java/org/donggle/backend/TestFixtures.java
@@ -37,6 +37,7 @@ public class TestFixtures {
     public static final RefreshToken REFRESH_TOKEN = new RefreshToken("testRefreshToken", MEMBER);
 
     public static final Category BASIC_CATEGORY = Category.of(new CategoryName("기본"), MEMBER);
+    public static final Category ANOTHER_CATEGORY = Category.of(new CategoryName("추가"), MEMBER);
 
     public static final Writing WRITING_WITH_NORMAL_BLOCK = Writing.of(MEMBER, new Title("WRITING_WITH_NORMAL_BLOCK"),
             BASIC_CATEGORY,
@@ -53,7 +54,39 @@ public class TestFixtures {
             )
     );
 
-    public static final Writing GENERAL_WRITING = Writing.of(MEMBER, new Title("GENERAL_WRITING"),
+    public static final Writing GENERAL_WRITING1 = Writing.of(MEMBER, new Title("GENERAL_WRITING1"),
+            BASIC_CATEGORY,
+            List.of(
+                    new NormalBlock(
+                            Depth.from(1),
+                            BlockType.PARAGRAPH,
+                            RawText.from("테스트 글입니다"),
+                            List.of(
+                                    new Style(new StyleRange(0, 2), StyleType.BOLD),
+                                    new Style(new StyleRange(3, 4), StyleType.ITALIC)
+                            )
+                    ),
+                    new CodeBlock(
+                            Depth.from(1),
+                            BlockType.CODE_BLOCK,
+                            RawText.from("public static void main(String... args) {}"),
+                            Language.from("java")
+                    ),
+                    new ImageBlock(
+                            Depth.from(1),
+                            BlockType.IMAGE,
+                            new ImageUrl("localhost:8080/hello-world.png"),
+                            new ImageCaption("테스트 이미지")
+                    ),
+                    new HorizontalRulesBlock(
+                            Depth.from(1),
+                            BlockType.HORIZONTAL_RULES,
+                            RawText.from("")
+                    )
+            )
+    );
+
+    public static final Writing GENERAL_WRITING2 = Writing.of(MEMBER, new Title("GENERAL_WRITING2"),
             BASIC_CATEGORY,
             List.of(
                     new NormalBlock(

--- a/backend/src/test/java/org/donggle/backend/application/service/MemberServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/MemberServiceTest.java
@@ -29,8 +29,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.donggle.backend.TestFixtures.ANOTHER_CATEGORY;
 import static org.donggle.backend.TestFixtures.BASIC_CATEGORY;
-import static org.donggle.backend.TestFixtures.GENERAL_WRITING;
+import static org.donggle.backend.TestFixtures.GENERAL_WRITING1;
+import static org.donggle.backend.TestFixtures.GENERAL_WRITING2;
 import static org.donggle.backend.TestFixtures.MEMBER;
 import static org.donggle.backend.TestFixtures.MEMBER_CREDENTIALS;
 import static org.donggle.backend.TestFixtures.REFRESH_TOKEN;
@@ -107,17 +109,23 @@ class MemberServiceTest {
         final Member member = memberRepository.save(MEMBER);
         final MemberCredentials memberCredentials = memberCredentialsRepository.save(MEMBER_CREDENTIALS);
         final Category basicCategory = categoryRepository.save(BASIC_CATEGORY);
-        final Writing writing = writingRepository.save(GENERAL_WRITING);
+        final Category anotherCategory = categoryRepository.save(ANOTHER_CATEGORY);
+        basicCategory.changeNextCategory(anotherCategory);
+        final Writing writing1 = writingRepository.save(GENERAL_WRITING1);
+        final Writing writing2 = writingRepository.save(GENERAL_WRITING2);
+        writing1.changeNextWriting(writing2);
         final Blog blog = blogRepository.findByBlogType(BlogType.TISTORY).orElseThrow();
         final BlogWriting blogWriting = new BlogWriting(
                 blog,
-                GENERAL_WRITING,
+                GENERAL_WRITING1,
                 LocalDateTime.now(),
                 List.of("태그1", "태그2"),
                 "www.dongle.blog"
         );
         final BlogWriting savedBlogWriting = blogWritingRepository.save(blogWriting);
         final RefreshToken refreshToken = tokenRepository.save(REFRESH_TOKEN);
+        em.flush();
+        em.clear();
 
         // when
         memberService.deleteMember(member.getId());


### PR DESCRIPTION
### 🛠️ Issue

- close #487 

### ✅ Tasks
- 삭제 로직 구현
- 삭제에 대한 테스트 케이스 구현

### ⏰ Time Difference
- 1 -> 4

### 📝 Note
처음에 어떻게 삭제를 해야할지 많이 고민을 했습니다. 초반에 많이 해맸는데 제가 마주했던 문제는 다음과 같습니다.
1. 무결성 제약 조건 때문에 삭제해야 하는 엔티티들 간의 순서가 있었습니다.
2. 그 중에서 `Writing`과 `Category`는 맨 앞부터 하나씩 차례로 지워나가야만 했던 것도 유의해야 했습니다.
3. 이전의 쿼리에서 `DELETE`를 하더라도 그 즉시 `flush()`되는 것이 아니었기에 데이터의 정합성 문제(쓰기 지연 저장소에 있는 쿼리들이 반영되지 않는 문제)가 있었습니다.
4. `cascade = CascadeType.REMOVE`를 최대한 사용해 하나의 엔티티를 지우면 연관된 모든 엔티티를 지우도록 하려고 했지만, 결국 이를 사용하려면 연관된 엔티티 모두를 영속성 컨텍스트에 올려놔야만 가능한 일이었기에, 불필요한 조회 쿼리가 발생하기도 했습니다.

따라서 현재에는 벌크성 쿼리를 통해 영속성 컨텍스트와 별개로 데이터베이스에 바로 쿼리를 날리도록 하였습니다. 이때 `@Modifying`을 사용했는데 이에 대한 정리는 [동글 블로그](https://medium.com/dong-gle/%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%82%AD%EC%A0%9C-cdd21d7d1e67)에 올려놨습니다.


4번 문제는 조금 더 알아보고, 테스트해보고 공유할게요!
