### PR TITLE
[FE] refactor: `Button` focus 시 스타일링 제거

### DIFF
--- a/frontend/src/components/@common/Button/Button.tsx
+++ b/frontend/src/components/@common/Button/Button.tsx
@@ -1,4 +1,3 @@
-// import { HomeIcon } from 'assets/icons';
 import {
   CSSProperties,
   ComponentPropsWithRef,
@@ -66,10 +65,6 @@ const genVariantStyle = (variant: Required<Props>['variant']): RuleSet<object> =
           background-color: ${theme.color.primary};
           color: ${theme.color.gray2};
         }
-
-        &:focus {
-          box-shadow: 0 0 0 3px ${theme.color.primary};
-        }
       `}
     `,
     text: css`
@@ -80,10 +75,6 @@ const genVariantStyle = (variant: Required<Props>['variant']): RuleSet<object> =
 
         &:hover {
           background-color: ${theme.color.gray4};
-        }
-
-        &:focus {
-          box-shadow: 0 0 0 3px ${theme.color.gray4};
         }
       `}
     `,
@@ -96,10 +87,6 @@ const genVariantStyle = (variant: Required<Props>['variant']): RuleSet<object> =
 
         &:hover {
           background-color: ${theme.color.primaryHover};
-        }
-
-        &:focus {
-          box-shadow: 0 0 0 3px ${theme.color.primary};
         }
       `}
     `,


### PR DESCRIPTION
### 🛠️ Issue

- close #500 

### ✅ Tasks
- Button 컴포넌트의 focus 스타일 제거

### ⏰ Time Difference
- 0.1

### 📝 Note
focus 시 테두리 스타일은 box-shadow 속성을 통해 만들고 있는데, 배경색이 달라지면 그에 맞춰 구현하기가 좀 까다로워 집니다.
따라서 현재 variant에 따라 다른 동작을 보입니다.

https://github.com/woowacourse-teams/2023-dong-gle/assets/33623078/eb1eed7a-f46c-4970-93cf-aa74cfc5c23a

또한 현재 버튼의 테두리를 인지 할 새 없이 바로 페이지가 이동하는 경우가 대부분이기 때문에, 삭제해도 UX는 크게 변경점이 없다고 생각했습니다.

추가적으로 `Button` 컴포넌트 자체에 `Ripple` 컴포넌트를 적용해도 괜찮을 것 같지만, 마찬가지로

>현재 버튼의 테두리를 인지 할 새 없이 바로 페이지가 이동하는 경우가 대부분

의 이유때문에 도입은 고려해야할 것 같습니다.
