### PR TITLE
[FE] feat: 티스토리 발행 카테고리 선택 기능, 발행 탭 블로그 연결 버튼 추가

### DIFF
--- a/frontend/src/apis/blogs.ts
+++ b/frontend/src/apis/blogs.ts
@@ -4,4 +4,4 @@ import { GetTistoryCategoriesResponse } from 'types/apis/blogs';
 
 // GET: 티스토리 카테고리 요청
 export const getTistoryCategories = (): Promise<GetTistoryCategoriesResponse> =>
-  http.get(`${blogsURL}/tistory/category`);
+  http.get(`${blogsURL}/tistory/category`).json();

--- a/frontend/src/apis/blogs.ts
+++ b/frontend/src/apis/blogs.ts
@@ -1,0 +1,7 @@
+import { blogsURL } from 'constants/apis/url';
+import { http } from './fetch';
+import { GetTistoryCategoriesResponse } from 'types/apis/blogs';
+
+// GET: 티스토리 카테고리 요청
+export const getTistoryCategories = (): Promise<GetTistoryCategoriesResponse> =>
+  http.get(`${blogsURL}/tistory/category`);

--- a/frontend/src/assets/icons/category.svg
+++ b/frontend/src/assets/icons/category.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="current" height="current" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+
+<rect x="0" fill="none" width="20" height="20"/>
+
+<g>
+
+<path d="M5 7h13v10H2V4h7l2 2H4v9h1V7z"/>
+
+</g>
+
+</svg>

--- a/frontend/src/assets/icons/index.ts
+++ b/frontend/src/assets/icons/index.ts
@@ -30,3 +30,4 @@ export { ReactComponent as HomeBorderIcon } from './home-border.svg';
 export { ReactComponent as TimeIcon } from './time.svg';
 export { ReactComponent as PasswordIcon } from './password.svg';
 export { ReactComponent as PublishIcon } from './publish.svg';
+export { ReactComponent as CategoryIcon } from './category.svg';

--- a/frontend/src/components/PublishingPropertySection/PublishingPropertyStyle.ts
+++ b/frontend/src/components/PublishingPropertySection/PublishingPropertyStyle.ts
@@ -79,6 +79,10 @@ const PublishingPropertyStyle = {
     gap: 1rem;
   `,
 
+  TistoryCategorySelectWrapper: styled.div`
+    flex: 1;
+  `,
+
   TistoryCategorySelect: styled.select`
     width: 100%;
   `,

--- a/frontend/src/components/PublishingPropertySection/PublishingPropertyStyle.ts
+++ b/frontend/src/components/PublishingPropertySection/PublishingPropertyStyle.ts
@@ -78,6 +78,10 @@ const PublishingPropertyStyle = {
     flex-direction: column;
     gap: 1rem;
   `,
+
+  TistoryCategorySelect: styled.select`
+    width: 100%;
+  `,
 };
 
 export default PublishingPropertyStyle;

--- a/frontend/src/components/PublishingPropertySection/TistoryPublishingPropertySection.tsx
+++ b/frontend/src/components/PublishingPropertySection/TistoryPublishingPropertySection.tsx
@@ -17,7 +17,7 @@ import { default as S } from './PublishingPropertyStyle';
 import type { Blog } from 'types/domain';
 import Input from 'components/@common/Input/Input';
 import { dateFormatter } from 'utils/date';
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import Divider from 'components/@common/Divider/Divider';
 import { useTistoryCategories } from 'hooks/queries/blogs/useTistoryCategories';
 
@@ -110,14 +110,18 @@ const TistoryPublishingPropertySection = ({ writingId, publishTo, selectCurrentT
             카테고리
           </S.PropertyName>
           <div>
-            <select onChange={(e) => setCategoryId(e.target.value)}>
+            <S.TistoryCategorySelect
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => setCategoryId(e.target.value)}
+              disabled={isCategoryLoading}
+            >
+              {isCategoryLoading && <option hidden>불러오는 중입니다</option>}
               {categories &&
                 categories.map(({ id, name }) => (
                   <option key={id} value={id}>
                     {name}
                   </option>
                 ))}
-            </select>
+            </S.TistoryCategorySelect>
           </div>
         </S.PropertyRow>
         {publishStatus === 'PROTECT' && (

--- a/frontend/src/components/PublishingPropertySection/TistoryPublishingPropertySection.tsx
+++ b/frontend/src/components/PublishingPropertySection/TistoryPublishingPropertySection.tsx
@@ -2,7 +2,14 @@ import { css, styled } from 'styled-components';
 import TagInput from '../@common/TagInput/TagInput';
 import Button from '../@common/Button/Button';
 import Spinner from 'components/@common/Spinner/Spinner';
-import { LeftArrowHeadIcon, PasswordIcon, PublishIcon, TagIcon, TimeIcon } from 'assets/icons';
+import {
+  CategoryIcon,
+  LeftArrowHeadIcon,
+  PasswordIcon,
+  PublishIcon,
+  TagIcon,
+  TimeIcon,
+} from 'assets/icons';
 import { slideToLeft } from 'styles/animation';
 import { TabKeys } from 'components/WritingSideBar/WritingSideBar';
 import { useTistoryPublishingPropertySection } from './useTistoryPublishingPropertySection';
@@ -12,6 +19,7 @@ import Input from 'components/@common/Input/Input';
 import { dateFormatter } from 'utils/date';
 import { useState } from 'react';
 import Divider from 'components/@common/Divider/Divider';
+import { useTistoryCategories } from 'hooks/queries/blogs/useTistoryCategories';
 
 type Props = {
   writingId: number;
@@ -30,11 +38,13 @@ const TistoryPublishStatusList = Object.keys(
 ) as (keyof typeof TistoryPublishStatus)[];
 
 const TistoryPublishingPropertySection = ({ writingId, publishTo, selectCurrentTab }: Props) => {
+  const { categories, isLoading: isCategoryLoading } = useTistoryCategories();
   const {
     isLoading,
     propertyFormInfo,
     setTags,
     setPublishStatus,
+    setCategoryId,
     passwordRef,
     dateRef,
     timeRef,
@@ -91,6 +101,22 @@ const TistoryPublishingPropertySection = ({ writingId, publishTo, selectCurrentT
                   {TistoryPublishStatus[value]}
                 </option>
               ))}
+            </select>
+          </div>
+        </S.PropertyRow>
+        <S.PropertyRow>
+          <S.PropertyName>
+            <CategoryIcon width={12} height={12} />
+            카테고리
+          </S.PropertyName>
+          <div>
+            <select onChange={(e) => setCategoryId(e.target.value)}>
+              {categories &&
+                categories.map(({ id, name }) => (
+                  <option key={id} value={id}>
+                    {name}
+                  </option>
+                ))}
             </select>
           </div>
         </S.PropertyRow>

--- a/frontend/src/components/PublishingPropertySection/TistoryPublishingPropertySection.tsx
+++ b/frontend/src/components/PublishingPropertySection/TistoryPublishingPropertySection.tsx
@@ -115,12 +115,19 @@ const TistoryPublishingPropertySection = ({ writingId, publishTo, selectCurrentT
               disabled={isCategoryLoading}
             >
               {isCategoryLoading && <option hidden>불러오는 중입니다</option>}
-              {categories &&
-                categories.map(({ id, name }) => (
-                  <option key={id} value={id}>
-                    {name}
+              {categories && (
+                <>
+                  {/* 티스토리 "카테고리 없음" 카테고리의 id가 "0"임 */}
+                  <option key='0' value='0'>
+                    카테고리 없음
                   </option>
-                ))}
+                  {categories.map(({ id, name }) => (
+                    <option key={id} value={id}>
+                      {name}
+                    </option>
+                  ))}
+                </>
+              )}
             </S.TistoryCategorySelect>
           </div>
         </S.PropertyRow>

--- a/frontend/src/components/PublishingPropertySection/TistoryPublishingPropertySection.tsx
+++ b/frontend/src/components/PublishingPropertySection/TistoryPublishingPropertySection.tsx
@@ -109,7 +109,7 @@ const TistoryPublishingPropertySection = ({ writingId, publishTo, selectCurrentT
             <CategoryIcon width={12} height={12} />
             카테고리
           </S.PropertyName>
-          <div>
+          <S.TistoryCategorySelectWrapper>
             <S.TistoryCategorySelect
               onChange={(e: ChangeEvent<HTMLSelectElement>) => setCategoryId(e.target.value)}
               disabled={isCategoryLoading}
@@ -129,7 +129,7 @@ const TistoryPublishingPropertySection = ({ writingId, publishTo, selectCurrentT
                 </>
               )}
             </S.TistoryCategorySelect>
-          </div>
+          </S.TistoryCategorySelectWrapper>
         </S.PropertyRow>
         {publishStatus === 'PROTECT' && (
           <S.PropertyRow>

--- a/frontend/src/components/PublishingPropertySection/useTistoryPublishingPropertySection.ts
+++ b/frontend/src/components/PublishingPropertySection/useTistoryPublishingPropertySection.ts
@@ -19,7 +19,7 @@ export const useTistoryPublishingPropertySection = ({ selectCurrentTab }: Args) 
     tags: [],
     publishStatus: 'PUBLIC',
     password: '',
-    categoryId: '0', // TODO: 카테고리 선택 기능 추가
+    categoryId: '0', // 티스토리 기본 카테고리 id === '0'
     publishTime: '',
   });
   const toast = useToast();

--- a/frontend/src/components/PublishingPropertySection/useTistoryPublishingPropertySection.ts
+++ b/frontend/src/components/PublishingPropertySection/useTistoryPublishingPropertySection.ts
@@ -57,11 +57,16 @@ export const useTistoryPublishingPropertySection = ({ selectCurrentTab }: Args) 
     setPropertyFormInfo((prev) => ({ ...prev, publishStatus }));
   };
 
+  const setCategoryId = (categoryId: string) => {
+    setPropertyFormInfo((prev) => ({ ...prev, categoryId }));
+  };
+
   return {
     isLoading,
     propertyFormInfo,
     setTags,
     setPublishStatus,
+    setCategoryId,
     passwordRef,
     dateRef,
     timeRef,

--- a/frontend/src/components/PublishingSection/PublishingSection.tsx
+++ b/frontend/src/components/PublishingSection/PublishingSection.tsx
@@ -3,6 +3,8 @@ import { BLOG_ICON, BLOG_KOREAN, BLOG_LIST } from 'constants/blog';
 import type { Blog } from 'types/domain';
 import Button from 'components/@common/Button/Button';
 import { TabKeys } from 'components/WritingSideBar/WritingSideBar';
+import { useMember } from 'hooks/queries/useMember';
+import { usePageNavigate } from 'hooks/usePageNavigate';
 
 type Props = {
   onBlogButtonClick: (blog: Blog) => void;
@@ -10,6 +12,12 @@ type Props = {
 };
 
 const PublishingSection = ({ onTabClick, onBlogButtonClick }: Props) => {
+  const { tistory, medium } = useMember();
+  const { goMyPage } = usePageNavigate();
+
+  const 블로그가하나라도연결되었는지 = tistory?.isConnected || medium?.isConnected;
+  const 모든블로그가연결되었는지 = tistory?.isConnected && medium?.isConnected;
+
   const openPublishingPropertySection = (blog: Blog) => {
     onBlogButtonClick(blog);
 
@@ -27,22 +35,51 @@ const PublishingSection = ({ onTabClick, onBlogButtonClick }: Props) => {
   return (
     <S.PublishingSection>
       <S.PublishingTitle>발행하기</S.PublishingTitle>
-      <S.BlogPublishButtonList>
-        {Object.values(BLOG_LIST).map((name) => {
-          return (
-            <Button
-              key={name}
-              size='medium'
-              block
-              align='left'
-              icon={BLOG_ICON[name]}
-              onClick={() => openPublishingPropertySection(name)}
-            >
-              {BLOG_KOREAN[name]}
-            </Button>
-          );
-        })}
-      </S.BlogPublishButtonList>
+      {블로그가하나라도연결되었는지 ? (
+        <>
+          <S.BlogPublishButtonList>
+            {Object.values(BLOG_LIST).map((name) => {
+              // 연결 여부 확인을 위한 로직 추가
+              const shouldRenderButton =
+                (name === 'TISTORY' && tistory?.isConnected) ||
+                (name === 'MEDIUM' && medium?.isConnected);
+
+              // 연결이 확인되지 않으면, 버튼을 렌더링하지 않는다.
+              if (!shouldRenderButton) {
+                return null;
+              }
+              // 연결 안된 게 있으면 "다른 블로그 연결하기" 렌더링
+
+              return (
+                <Button
+                  key={name}
+                  size='medium'
+                  block
+                  align='left'
+                  icon={BLOG_ICON[name]}
+                  onClick={() => openPublishingPropertySection(name)}
+                >
+                  {BLOG_KOREAN[name]}
+                </Button>
+              );
+            })}
+          </S.BlogPublishButtonList>
+          {!모든블로그가연결되었는지 && (
+            <S.AddBlogConnectionButton onClick={goMyPage}>
+              블로그 추가로 연결하기
+            </S.AddBlogConnectionButton>
+          )}
+        </>
+      ) : (
+        <S.AddFirstBlogConnectionContainer>
+          <S.AddFirstBlogConnectionText>
+            블로그를 연결해서 글을 발행해보세요!
+          </S.AddFirstBlogConnectionText>
+          <Button variant='secondary' onClick={goMyPage}>
+            연결 하러가기
+          </Button>
+        </S.AddFirstBlogConnectionContainer>
+      )}
     </S.PublishingSection>
   );
 };
@@ -70,5 +107,28 @@ const S = {
 
   ButtonContent: styled.div`
     display: flex;
+  `,
+
+  AddBlogConnectionButton: styled.button`
+    color: ${({ theme }) => theme.color.gray7};
+
+    &:hover {
+      color: ${({ theme }) => theme.color.gray9};
+    }
+
+    &:active {
+      color: ${({ theme }) => theme.color.gray7};
+    }
+  `,
+
+  AddFirstBlogConnectionContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 2rem;
+  `,
+
+  AddFirstBlogConnectionText: styled.p`
+    font-size: 1.5rem;
   `,
 };

--- a/frontend/src/constants/apis/url.ts
+++ b/frontend/src/constants/apis/url.ts
@@ -8,3 +8,4 @@ export const memberURL = `${baseURL}/member`;
 export const connectionsURL = `${baseURL}/connections`;
 export const loginURL = `${baseURL}/auth/login`;
 export const authURL = `${baseURL}/auth`;
+export const blogsURL = `${baseURL}/blogs`;

--- a/frontend/src/hooks/queries/blogs/useTistoryCategories.ts
+++ b/frontend/src/hooks/queries/blogs/useTistoryCategories.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { getTistoryCategories } from 'apis/blogs';
+import { useToast } from 'hooks/@common/useToast';
+import { GetTistoryCategoriesResponse } from 'types/apis/blogs';
+
+export const useTistoryCategories = () => {
+  const toast = useToast();
+  const { data, isLoading } = useQuery<GetTistoryCategoriesResponse>(
+    ['tistoryCategories'],
+    getTistoryCategories,
+    {
+      onError: () =>
+        toast.show({ type: 'error', message: '티스토리 카테고리 목록을 불러오지 못했습니다.' }),
+    },
+  );
+
+  return { categories: data?.categories, isLoading };
+};

--- a/frontend/src/types/apis/blogs.ts
+++ b/frontend/src/types/apis/blogs.ts
@@ -1,0 +1,8 @@
+type TistoryCategory = {
+  id: string;
+  name: string;
+};
+
+export type GetTistoryCategoriesResponse = {
+  categories: TistoryCategory[];
+};


### PR DESCRIPTION
### 🛠️ Issue

- close #477
- close #515

### ✅ Tasks
- 티스토리 발행 시 카테고리 선택 기능
  - <img width="305" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/33623078/ebcaf597-6265-439b-b355-201869a74655">

- 발행 탭에 연결 블로그 없는 경우 마이 페이지로 이동하는 버튼 추가
  - 모든 블로그를 연결하지 않은 경우
    <img width="299" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/33623078/27180fdf-4819-47e1-b570-518f37d64cd3">
  - 하나만 연결한 경우
    <img width="329" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/33623078/7edafabb-bd7f-401a-b646-2c03d39babcd">
  - 모두 연결한 경우
    <img width="301" alt="image" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/33623078/ed27f799-f2b7-4b44-b890-f3a36bfedd6b">


### ⏰ Time Difference
- 6 + 2

### 📝 Note

1. 카테고리 select `width`를 `100%`로 고정하고 싶은데 어떻게 해야할 지 모르겠네요ㅠ
2. <S.TistoryCategorySelect
              onChange={(e: ChangeEvent<HTMLSelectElement>) => setCategoryId(e.target.value)}
              disabled={isCategoryLoading}
            > 에서 onChange={(e: ChangeEvent<HTMLSelectElement>) => setCategoryId(e.target.value)} 이 부분이 의아할 수 있는데, styled로 select 태그를 쓰니까 `e` 타입을 감지못하더라구요. 그래서 저렇게 명시해두었습니다.

