### PR TITLE
[FE] fix: 글 복구, 글 삭제 관련 invalidateQueries 설정

### DIFF
--- a/frontend/src/components/Category/WritingList/useDeleteWritings.ts
+++ b/frontend/src/components/Category/WritingList/useDeleteWritings.ts
@@ -11,6 +11,7 @@ export const useDeleteWritings = () => {
   const { mutate } = useMutation(moveToTrash, {
     onSuccess: () => {
       toast.show({ type: 'success', message: '글이 휴지통으로 이동됐습니다.' });
+      queryClient.invalidateQueries(['deletedWritings']);
       queryClient.invalidateQueries(['writingsInCategory']);
       goTrashCanPage();
     },

--- a/frontend/src/components/TrashCanTable/useRestoreDeletedWritings.ts
+++ b/frontend/src/components/TrashCanTable/useRestoreDeletedWritings.ts
@@ -10,6 +10,7 @@ export const useRestoreDeleteWritings = () => {
     onSuccess: () => {
       toast.show({ type: 'success', message: '글이 복구되었습니다.' });
       queryClient.invalidateQueries(['deletedWritings']);
+      queryClient.invalidateQueries(['writingsInCategory']);
     },
     onError: (error) => {
       if (error instanceof HttpError) toast.show({ type: 'error', message: error.message });


### PR DESCRIPTION
### 🛠️ Issue

- close #512 

### ✅ Tasks
- [x] 글 복구 시, invalidateQueries에 카테고리 글 query키 추가
- [x] 글 삭제 시, invalidateQueries에 휴지통 페이지 글 query키 추가

### ⏰ Time Difference
- 1 -> 0.5

### 📝 Note
현재 mocking으로만 작업해서 제대로 동작하는지 확인은 되지 않지만, 현재는 React query devtools로 확인한 결과 원하는대로 refetch 하는 것을 확인했습니다.

추후 쿠마의 msw가 머지되면 제대로 테스트한 뒤에 다시 리뷰 요청하겠습니다.

https://github.com/woowacourse-teams/2023-dong-gle/assets/64737872/0aeb5f2d-a975-4478-af6c-a2d9348aa652
