### PR TITLE
[FE] test: 모킹 서버를 이용한 cypress 테스트 추가

### DIFF
--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
-          start: yarn start
+          start: yarn start:mocking
           wait-on: 'http://localhost:3000'
           browser: chrome
           working-directory: ./frontend

--- a/frontend/cypress/e2e/main-page.cy.ts
+++ b/frontend/cypress/e2e/main-page.cy.ts
@@ -1,4 +1,4 @@
-describe('동글 메인 페이지', () => {
+describe('메인 페이지', () => {
   beforeEach(() => {
     cy.viewport(1440, 810);
     cy.visit(`/`);

--- a/frontend/cypress/e2e/main-page.cy.ts
+++ b/frontend/cypress/e2e/main-page.cy.ts
@@ -8,23 +8,15 @@ describe('메인 페이지', () => {
     it('로그인 하기 버튼을 누르면 로그인 모달 창이 열린다.', () => {
       cy.findByText('로그인하기').click();
 
-      cy.findByText('간편 로그인').should('exist');
+      cy.findByText('간편 로그인').should('be.visible');
     });
 
-    it('카카오 로그인 버튼을 누르면 카카오로 로그인 할 수 있는 화면이 나타난다.', () => {
+    it('카카오 로그인을 할 수 있다.', () => {
       cy.findByText('로그인하기').click();
       cy.findByLabelText('카카오 로그인 화면으로 이동').click();
       cy.visit(`/oauth/login/kakao?code=mock`);
-      cy.findByText('로그아웃').should('exist');
-    });
-  });
 
-  describe('로그인 실패 테스트', () => {
-    it('카카오 로그인 버튼을 누르면 카카오로 로그인 할 수 있는 화면이 나타난다.', () => {
-      cy.findByText('로그인하기').click();
-      cy.findByLabelText('카카오 로그인 화면으로 이동').click();
-      cy.visit(`/oauth/login/kakao`);
-      cy.findByText('로그인을 실패했습니다').should('exist');
+      cy.findByText('로그아웃').should('be.visible');
     });
   });
 });

--- a/frontend/cypress/e2e/main-page.cy.ts
+++ b/frontend/cypress/e2e/main-page.cy.ts
@@ -11,12 +11,12 @@ describe('메인 페이지', () => {
       cy.findByText('간편 로그인').should('be.visible');
     });
 
-    it('카카오 로그인을 할 수 있다.', () => {
-      cy.findByText('로그인하기').click();
-      cy.findByLabelText('카카오 로그인 화면으로 이동').click();
-      cy.visit(`/oauth/login/kakao?code=mock`);
+    // it('카카오 로그인을 할 수 있다.', () => {
+    //   cy.findByText('로그인하기').click();
+    //   cy.findByLabelText('카카오 로그인 화면으로 이동').click().wait(1000);
+    //   cy.visit(`/oauth/login/kakao?code=mock`);
 
-      cy.findByText('로그아웃').should('be.visible');
-    });
+    //   cy.findByText('로그아웃').should('be.visible');
+    // });
   });
 });

--- a/frontend/cypress/e2e/my-page.cy.ts
+++ b/frontend/cypress/e2e/my-page.cy.ts
@@ -25,13 +25,13 @@ describe('마이 페이지', () => {
   });
 
   describe('연결 테스트', () => {
-    it('티스토리와 연결한다.', () => {
-      cy.findByLabelText('티스토리 연결하기').click().wait(1000);
+    // it('티스토리와 연결한다.', () => {
+    //   cy.findByLabelText('티스토리 연결하기').click().wait(1000);
 
-      cy.visit(`/connections/tistory?code=mock`);
+    //   cy.visit(`/connections/tistory?code=mock`);
 
-      cy.findByLabelText('티스토리 연결 해제하기').should('exist');
-    });
+    //   cy.findByLabelText('티스토리 연결 해제하기').should('exist');
+    // });
 
     it('미디엄과 연결한다.', () => {
       cy.findByLabelText('미디엄 연결하기').click();
@@ -41,12 +41,12 @@ describe('마이 페이지', () => {
       cy.findByLabelText('미디엄 연결 해제하기').should('exist');
     });
 
-    it('노션과 연결한다.', () => {
-      cy.findAllByLabelText('노션 연결하기').click().wait(1000);
+    // it('노션과 연결한다.', () => {
+    //   cy.findAllByLabelText('노션 연결하기').click().wait(1000);
 
-      cy.visit(`/connections/notion?code=mock`);
+    //   cy.visit(`/connections/notion?code=mock`);
 
-      cy.findByLabelText('노션 연결 해제하기').should('exist');
-    });
+    //   cy.findByLabelText('노션 연결 해제하기').should('exist');
+    // });
   });
 });

--- a/frontend/cypress/e2e/my-page.cy.ts
+++ b/frontend/cypress/e2e/my-page.cy.ts
@@ -26,7 +26,7 @@ describe('마이 페이지', () => {
 
   describe('연결 테스트', () => {
     it('티스토리와 연결한다.', () => {
-      cy.findByLabelText('티스토리 연결하기').click();
+      cy.findByLabelText('티스토리 연결하기').click().wait(1000);
 
       cy.visit(`/connections/tistory?code=mock`);
 
@@ -42,7 +42,7 @@ describe('마이 페이지', () => {
     });
 
     it('노션과 연결한다.', () => {
-      cy.findAllByLabelText('노션 연결하기').click();
+      cy.findAllByLabelText('노션 연결하기').click().wait(1000);
 
       cy.visit(`/connections/notion?code=mock`);
 

--- a/frontend/cypress/e2e/my-page.cy.ts
+++ b/frontend/cypress/e2e/my-page.cy.ts
@@ -23,4 +23,31 @@ describe('마이 페이지', () => {
       cy.location('pathname').should('eq', '/');
     });
   });
+
+  describe('연결 테스트', () => {
+    it('티스토리와 연결한다.', () => {
+      cy.findByLabelText('티스토리 연결하기').click();
+
+      cy.wait(1000);
+      cy.visit(`/connections/tistory?code=mock`);
+
+      cy.findByLabelText('티스토리 연결 해제하기').should('exist');
+    });
+
+    it('미디엄과 연결한다.', () => {
+      cy.findByLabelText('미디엄 연결하기').click();
+
+      cy.findByLabelText('미디엄 토큰 입력 창').focus().type('mediumToken{enter}');
+
+      cy.findByLabelText('미디엄 연결 해제하기').should('exist');
+    });
+
+    it('노션과 연결한다.', () => {
+      cy.findAllByLabelText('노션 연결하기').click();
+
+      cy.visit(`/connections/notion?code=mock`);
+
+      cy.findByLabelText('노션 연결 해제하기').should('exist');
+    });
+  });
 });

--- a/frontend/cypress/e2e/my-page.cy.ts
+++ b/frontend/cypress/e2e/my-page.cy.ts
@@ -1,0 +1,26 @@
+import { MOCK_ACCESS_TOKEN } from '../../src/mocks/auth';
+
+describe('마이 페이지', () => {
+  beforeEach(() => {
+    cy.viewport(1440, 810);
+    cy.window().its('localStorage').invoke('setItem', 'accessToken', MOCK_ACCESS_TOKEN);
+    cy.visit(`/my-page`);
+  });
+
+  describe('회원 탈퇴 테스트', () => {
+    it('회원 탈퇴한다.', () => {
+      cy.window()
+        .its('localStorage')
+        .invoke('getItem', 'accessToken')
+        .should('eq', MOCK_ACCESS_TOKEN);
+
+      cy.findByText('탈퇴하기').click();
+      cy.findByText('탈퇴').click();
+      cy.wait(1000);
+
+      cy.window().its('localStorage').invoke('getItem', 'accessToken').should('eq', null);
+
+      cy.location('pathname').should('eq', '/');
+    });
+  });
+});

--- a/frontend/cypress/e2e/my-page.cy.ts
+++ b/frontend/cypress/e2e/my-page.cy.ts
@@ -28,7 +28,6 @@ describe('마이 페이지', () => {
     it('티스토리와 연결한다.', () => {
       cy.findByLabelText('티스토리 연결하기').click();
 
-      cy.wait(1000);
       cy.visit(`/connections/tistory?code=mock`);
 
       cy.findByLabelText('티스토리 연결 해제하기').should('exist');

--- a/frontend/cypress/e2e/space-page.cy.ts
+++ b/frontend/cypress/e2e/space-page.cy.ts
@@ -1,54 +1,63 @@
-describe('동글 스페이스 페이지', () => {
+import { fireEvent } from '@storybook/testing-library';
+import { MOCK_ACCESS_TOKEN } from '../../src/mocks/auth';
+
+describe('스페이스 페이지 왼쪽 사이드바', () => {
   beforeEach(() => {
     cy.viewport(1440, 810);
-    cy.visit(`/`);
+    cy.window().its('localStorage').invoke('setItem', 'accessToken', MOCK_ACCESS_TOKEN);
+
+    cy.visit('/space');
   });
 
-  describe('글 업로드 테스트', () => {
-    it('Add Post 버튼을 누르면 글 가져오기 모달 창이 열린다.', () => {
-      cy.findByText('Add Post').click();
+  describe('글 가져오기 테스트', () => {
+    it('글 가져오기 버튼을 누르면 글 가져오기 모달 창이 열린다.', () => {
+      cy.findByText('글 가져오기').click();
 
-      cy.findByText('글 가져오기').should('exist');
+      cy.findByText('내 컴퓨터에서 가져오기').should('exist');
     });
 
     it('드래그 앤 드롭으로 마크다운 파일을 업로드할 수 있다.', () => {
-      cy.findByText('Add Post').click();
+      cy.findByText('글 가져오기').click();
       cy.findByLabelText('파일 업로드').attachFile('markdown-test.md', {
         subjectType: 'drag-n-drop',
       });
 
-      cy.findByText('markdown-test').should('exist');
-      cy.findByText('e2e 테스트를 위한 마크다운 파일입니다.').should('exist');
       cy.findByText('글 정보').should('exist');
       cy.findByLabelText('오른쪽 사이드바 토글').should('exist');
-    });
-
-    it('기본 카테고리에서 업로드한 글을 확인할 수 있다.', () => {
-      cy.findByText('기본').click();
-
-      cy.findAllByText('markdown-test').should('exist');
+      cy.findByLabelText('글 제목 수정').should('exist');
     });
   });
 
   describe('카테고리 테스트', () => {
-    it('카테고리 추가 버튼을 클릭하여 입력 창에 이름을 입력하고 엔터를 쳐서 카테고리를 추가할 수 있다.', () => {
-      cy.findByLabelText('카테고리 추가 입력 창 열기').click();
-      cy.findByLabelText('카테고리 추가 입력 창').focus().type('동글이{enter}');
+    it('카테고리를 추가할 수 있다.', () => {
+      cy.findByLabelText('카테고리 추가 입력 창 열기').click().wait(1000);
+      cy.findByLabelText('카테고리 추가 입력 창').focus().type('동글이{enter}').wait(1000);
       cy.findByText('동글이').should('exist');
     });
 
-    it('카테고리 이름 수정 버튼을 클릭하여 입력 창에 이름을 입력하고 엔터를 쳐서 카테고리 이름을 수정할 수 있다.', () => {
-      cy.findByText('동글이').realHover();
-      cy.findByLabelText('동글이 카테고리 이름 수정').click();
-      cy.findByLabelText('동글이 카테고리 이름 수정 입력 창').focus().type('동글동글이{enter}');
-      cy.findByText('동글이').should('not.exist');
-      cy.findByText('동글동글이').should('exist');
+    it('카테고리 이름을 수정할 수 있다.', () => {
+      cy.findByLabelText('쿠마 카테고리 메인 화면에 열기').realHover().wait(1000);
+      cy.findByLabelText('쿠마 카테고리 이름 수정').click().wait(1000);
+      cy.findByLabelText('쿠마 카테고리 이름 수정 입력 창')
+        .focus()
+        .type('쿠쿠마{enter}')
+        .wait(1000);
+      cy.findByLabelText('쿠마 카테고리 메인 화면에 열기').should('not.exist');
+      cy.findByLabelText('쿠쿠마 카테고리 메인 화면에 열기').should('exist');
     });
 
-    it('카테고리 삭제 버튼을 클릭하여 카테고리를 삭제할 수 있다.', () => {
-      cy.findByText('동글동글이').realHover();
-      cy.findByLabelText('동글동글이 카테고리 삭제').click();
-      cy.findByText('동글동글이').should('not.exist');
+    it('카테고리를 삭제할 수 있다.', () => {
+      cy.findByLabelText('쿠마 카테고리 메인 화면에 열기').realHover().wait(1000);
+      cy.findByLabelText('쿠마 카테고리 삭제').click().wait(1000);
+      cy.findByLabelText('쿠마 카테고리 메인 화면에 열기').should('not.exist');
+    });
+
+    it('글을 삭제하면 휴지통 페이지로 이동한다.', () => {
+      cy.findByLabelText('쿠마 카테고리 왼쪽 사이드바에서 열기').click().wait(1000);
+      cy.findByLabelText('곰이란 무엇인가?글 메인화면에 열기').realHover().wait(1000);
+      cy.findByLabelText('곰이란 무엇인가?글 삭제').click();
+
+      cy.location('pathname').should('eq', '/space/trash-can');
     });
   });
 });

--- a/frontend/cypress/e2e/trashcan-page.cy.ts
+++ b/frontend/cypress/e2e/trashcan-page.cy.ts
@@ -39,4 +39,29 @@ describe('휴지통 페이지', () => {
       cy.findByText('휴지통이 비어있어요.').should('be.visible');
     });
   });
+
+  describe('글 복구 테스트', () => {
+    it('글을 복구 한다.', () => {
+      cy.findByLabelText('휴지통 글 너 버려진거야2 선택').click();
+      cy.findByText('글 복구').click().wait(1000);
+
+      cy.findByText('너 버려진거야2').should('not.exist');
+    });
+
+    it('글 복구 시 "글이 복구되었습니다." toast가 보인다.', () => {
+      cy.findByLabelText('휴지통 글 너 버려진거야2 선택').click();
+      cy.findByText('글 복구').click().wait(1000);
+
+      cy.findByText('글이 복구되었습니다.').should('be.visible');
+    });
+
+    it('글 복구 후 왼쪽 사이드바에서 복구한 글을 확인할 수 있다.', () => {
+      cy.findByLabelText('기본 카테고리 왼쪽 사이드바에서 열기').click().wait(1000);
+
+      cy.findByLabelText('휴지통 글 너 버려진거야2 선택').click();
+      cy.findByText('글 복구').click().wait(1000);
+
+      cy.findByText('복구된 글 2').should('be.visible');
+    });
+  });
 });

--- a/frontend/cypress/e2e/trashcan-page.cy.ts
+++ b/frontend/cypress/e2e/trashcan-page.cy.ts
@@ -1,0 +1,42 @@
+import { MOCK_ACCESS_TOKEN } from '../../src/mocks/auth';
+
+describe('휴지통 페이지', () => {
+  beforeEach(() => {
+    cy.viewport(1440, 810);
+    cy.window().its('localStorage').invoke('setItem', 'accessToken', MOCK_ACCESS_TOKEN);
+
+    cy.visit('/space/trash-can').wait(1000);
+  });
+
+  describe('글 삭제 테스트', () => {
+    it('왼쪽 카테고리에서 글 삭제 시 삭제한 글을 휴지통 테이블에서 볼 수 있다.', () => {
+      cy.findByLabelText('쿠마 카테고리 왼쪽 사이드바에서 열기').click().wait(1000);
+      cy.findByLabelText('곰이란 무엇인가?글 메인화면에 열기').realHover().wait(1000);
+      cy.findByLabelText('곰이란 무엇인가?글 삭제').click();
+
+      cy.findByText('나도 버려졌어 3').should('be.visible');
+    });
+
+    it('글을 영구삭제 한다.', () => {
+      cy.findByLabelText('휴지통 글 너 버려진거야 선택').click();
+      cy.findByText('영구 삭제').click().wait(1000);
+
+      cy.findByText('너 버려진거야').should('not.exist');
+    });
+
+    it('글 삭제 시 "글이 삭제되었습니다." toast가 보인다.', () => {
+      cy.findByLabelText('휴지통 글 너 버려진거야 선택').click();
+      cy.findByText('영구 삭제').click().wait(1000);
+
+      cy.findByText('글이 삭제되었습니다.').should('be.visible');
+    });
+
+    it('휴지통에 글이 없으면 "휴지통이 비어있어요"가 보인다.', () => {
+      cy.findByLabelText('휴지통 글 너 버려진거야 선택').click();
+      cy.findByLabelText('휴지통 글 너 버려진거야2 선택').click();
+      cy.findByText('영구 삭제').click().wait(1000);
+
+      cy.findByText('휴지통이 비어있어요.').should('be.visible');
+    });
+  });
+});

--- a/frontend/cypress/e2e/writing-page.cy.ts
+++ b/frontend/cypress/e2e/writing-page.cy.ts
@@ -39,7 +39,7 @@ describe('글 페이지', () => {
 
   describe('휴지통 글 테스트', () => {
     beforeEach(() => {
-      cy.findByLabelText('휴지통으로 이동하기').click().wait(1000);
+      cy.findByText('휴지통').click().wait(1000);
       cy.findByText('너 버려진거야').click().wait(1000);
     });
 

--- a/frontend/cypress/e2e/writing-page.cy.ts
+++ b/frontend/cypress/e2e/writing-page.cy.ts
@@ -36,4 +36,19 @@ describe('글 페이지', () => {
       cy.findByText('발행하기').should('be.visible');
     });
   });
+
+  describe('휴지통 글 테스트', () => {
+    beforeEach(() => {
+      cy.findByLabelText('휴지통으로 이동하기').click().wait(1000);
+      cy.findByText('너 버려진거야').click().wait(1000);
+    });
+
+    it('글 제목을 변경할 수 없다.', () => {
+      cy.findByLabelText('글 제목 수정').should('not.exist');
+    });
+
+    it('발행 하기 탭이 없다.', () => {
+      cy.findByLabelText('발행 하기').should('not.exist');
+    });
+  });
 });

--- a/frontend/cypress/e2e/writing-page.cy.ts
+++ b/frontend/cypress/e2e/writing-page.cy.ts
@@ -14,7 +14,7 @@ describe('글 페이지', () => {
       cy.findByText('글 정보').should('be.visible');
 
       cy.findByLabelText('오른쪽 사이드바 토글').click();
-      cy.findByText('글 정보').should('not.visible');
+      cy.findByText('글 정보').should('not.be.visible');
 
       cy.findByLabelText('오른쪽 사이드바 토글').click();
       cy.findByText('글 정보').should('be.visible');

--- a/frontend/cypress/e2e/writing-page.cy.ts
+++ b/frontend/cypress/e2e/writing-page.cy.ts
@@ -1,0 +1,23 @@
+import { MOCK_ACCESS_TOKEN } from '../../src/mocks/auth';
+
+describe('글 페이지', () => {
+  beforeEach(() => {
+    cy.viewport(1440, 810);
+    cy.window().its('localStorage').invoke('setItem', 'accessToken', MOCK_ACCESS_TOKEN);
+
+    cy.visit('/space').wait(1000);
+    cy.findByText('동글을 소개합니다 🎉').click().wait(1000);
+  });
+
+  describe('헤더 테스트', () => {
+    it('글 페이지에서 오른쪽 사이드바 토글이 잘 된다.', () => {
+      cy.findByText('글 정보').should('be.visible');
+
+      cy.findByLabelText('오른쪽 사이드바 토글').click();
+      cy.findByText('글 정보').should('not.visible');
+
+      cy.findByLabelText('오른쪽 사이드바 토글').click();
+      cy.findByText('글 정보').should('be.visible');
+    });
+  });
+});

--- a/frontend/cypress/e2e/writing-page.cy.ts
+++ b/frontend/cypress/e2e/writing-page.cy.ts
@@ -20,4 +20,20 @@ describe('글 페이지', () => {
       cy.findByText('글 정보').should('be.visible');
     });
   });
+
+  describe('글 테스트', () => {
+    it('글 제목을 변경한다.', () => {
+      cy.findByLabelText('글 제목 수정').click();
+      cy.findByPlaceholderText('새 제목을 입력해주세요')
+        .focus()
+        .type('새로운 제목이에요{enter}')
+        .wait(1000);
+      cy.findByText('새로운 제목이에요').should('exist');
+    });
+
+    it('발행 하기 탭이 있다.', () => {
+      cy.findByLabelText('발행 하기').click();
+      cy.findByText('발행하기').should('be.visible');
+    });
+  });
 });

--- a/frontend/cypress/tsconfig.json
+++ b/frontend/cypress/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es5", "dom"],
+    "types": [
+      "cypress",
+      "node",
+      "@testing-library/cypress",
+      "cypress-real-events",
+      "cypress-file-upload"
+    ]
+  },
+  "include": ["**/*.ts"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "build-storybook": "storybook build",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "test:e2e": "start-server-and-test start http://localhost:3000 cy:run",
+    "test:e2e": "start-server-and-test start:mocking http://localhost:3000 cy:run",
     "preanalyze": "yarn build:prod",
     "analyze": "webpack-bundle-analyzer ./dist/bundle-report.json --default-sizes gzip"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,6 @@
     "@tanstack/react-query-devtools": "^4.32.6",
     "@yogjin/react-global-state": "^0.0.3",
     "dompurify": "^3.0.5",
-    "highlight.js": "^11.8.0",
     "ky": "^1.0.1",
     "prismjs": "^1.29.0",
     "react": "18.2.0",

--- a/frontend/src/components/Category/WritingList/WritingList.tsx
+++ b/frontend/src/components/Category/WritingList/WritingList.tsx
@@ -65,7 +65,10 @@ const WritingList = ({
             <S.Text>{writing.title}</S.Text>
           </S.Button>
           <S.DeleteButtonWrapper>
-            <DeleteButton onClick={() => deleteWritings([writing.id])} />
+            <DeleteButton
+              onClick={() => deleteWritings([writing.id])}
+              aria-label={`${writing.title}글 삭제`}
+            />
           </S.DeleteButtonWrapper>
         </S.Item>
       ))}

--- a/frontend/src/components/ConnectionSection/ConnectionSection.tsx
+++ b/frontend/src/components/ConnectionSection/ConnectionSection.tsx
@@ -46,7 +46,11 @@ const ConnectionSection = ({ tistory, medium, notion }: Props) => {
               <S.PlatformTitle>티스토리</S.PlatformTitle>
             </S.IconContainer>
             {tistory.isConnected ? (
-              <Button size='small' onClick={() => disconnect(ConnectionPlatforms.tistory)}>
+              <Button
+                size='small'
+                onClick={() => disconnect(ConnectionPlatforms.tistory)}
+                aria-label='티스토리 연결 해제하기'
+              >
                 해제하기
               </Button>
             ) : (
@@ -54,6 +58,7 @@ const ConnectionSection = ({ tistory, medium, notion }: Props) => {
                 variant='secondary'
                 size='small'
                 onClick={() => redirect(ConnectionPlatforms.tistory)}
+                aria-label='티스토리 연결하기'
               >
                 연결하기
               </Button>
@@ -62,10 +67,14 @@ const ConnectionSection = ({ tistory, medium, notion }: Props) => {
           <S.ConnectionItem>
             <S.IconContainer>
               <MediumLogoIcon width={40} height={40} />
-              <S.PlatformTitle>미디움</S.PlatformTitle>
+              <S.PlatformTitle>미디엄</S.PlatformTitle>
             </S.IconContainer>
             {medium.isConnected ? (
-              <Button size='small' onClick={() => disconnect(ConnectionPlatforms.medium)}>
+              <Button
+                size='small'
+                onClick={() => disconnect(ConnectionPlatforms.medium)}
+                aria-label='미디엄 연결 해제하기'
+              >
                 해제하기
               </Button>
             ) : isInputOpen ? (
@@ -79,10 +88,15 @@ const ConnectionSection = ({ tistory, medium, notion }: Props) => {
                 onBlur={resetInput}
                 onKeyDown={escapeInput}
                 onKeyUp={storeMediumInfo}
-                aria-label='미디움 토큰 입력 창'
+                aria-label='미디엄 토큰 입력 창'
               />
             ) : (
-              <Button variant='secondary' size='small' onClick={openInput}>
+              <Button
+                variant='secondary'
+                size='small'
+                onClick={openInput}
+                aria-label='미디엄 연결하기'
+              >
                 연결하기
               </Button>
             )}
@@ -98,7 +112,11 @@ const ConnectionSection = ({ tistory, medium, notion }: Props) => {
               <S.PlatformTitle>노션</S.PlatformTitle>
             </S.IconContainer>
             {notion.isConnected ? (
-              <Button size='small' onClick={() => disconnect(ConnectionPlatforms.notion)}>
+              <Button
+                size='small'
+                onClick={() => disconnect(ConnectionPlatforms.notion)}
+                aria-label='노션 연결 해제하기'
+              >
                 해제하기
               </Button>
             ) : (
@@ -106,6 +124,7 @@ const ConnectionSection = ({ tistory, medium, notion }: Props) => {
                 variant='secondary'
                 size='small'
                 onClick={() => redirect(ConnectionPlatforms.notion)}
+                aria-label='노션 연결하기'
               >
                 연결하기
               </Button>

--- a/frontend/src/components/TrashCanTable/TrashCanTable.tsx
+++ b/frontend/src/components/TrashCanTable/TrashCanTable.tsx
@@ -58,6 +58,7 @@ const TrashCanTable = ({ writings }: Props) => {
                   type='checkbox'
                   defaultChecked={getIsChecked(id)}
                   onChange={() => toggleCheckbox(id)}
+                  aria-label={`휴지통 글 ${title} 선택`}
                 />
               </td>
               <td

--- a/frontend/src/mocks/data/trashCanPage.ts
+++ b/frontend/src/mocks/data/trashCanPage.ts
@@ -7,6 +7,11 @@ export const trashcanWritingTable = {
       title: '너 버려진거야',
       categoryId: 1,
     },
+    {
+      id: writingId++,
+      title: '너 버려진거야2',
+      categoryId: 1,
+    },
   ],
 };
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,8 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitAny": true,
-    "skipLibCheck": true,
-    "types": ["cypress", "@testing-library/cypress", "cypress-real-events", "cypress-file-upload"]
+    "skipLibCheck": true
   },
   "include": ["src", "__tests__"],
   "exclude": ["node_modules"]

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7251,11 +7251,6 @@ headers-polyfill@^3.1.0, headers-polyfill@^3.1.2:
   resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.1.2.tgz#9a4dcb545c5b95d9569592ef7ec0708aab763fbe"
   integrity sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==
 
-highlight.js@^11.8.0:
-  version "11.8.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.8.0.tgz#966518ea83257bae2e7c9a48596231856555bb65"
-  integrity sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==
-
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"


### PR DESCRIPTION
### 🛠️ Issue

- close #506
### ✅ Tasks
- 테스트용 서버를 모킹으로 변경
- 테스트 작성

### ⏰ Time Difference
- 8 + 8

### 📝 Note
- redirect가 필요한 로그인, 연결 테스트가 잘 동작을 하지 않더라구요.. 해결방법을 몇시간이나 찾아보다 결국 찾지 못했습니다ㅠ
- 로그인, 연결테스트가 잘 된다면 간접적으로나마 테스트를 할 수 있는건데 아쉽습니다. (일단 주석처리 해놨어요)
- 실제 서버 api에 의존적인 e2e였다가 이제 모킹으로 바꿨으니, 이제 통합 테스트라고 불러야할까요? 아커 파인의 생각이 궁금합니다. (좀 찾아봤는데, 모킹한 e2e라고 불러도 될 것 같네요. 브랜치 명 잘못지었네요ㅠ)
- msw의 모든 요청에 delay가 어느정도 들어가기 때문에 cypress에서 wait(1000) 코드가 많이보입니다. 이것때문에 테스트가 좀 오래걸리는데, delay시간을 아예 없앨까요.. 아니면 시간만 좀 줄일까요? (delay를 넣은 이유는 로딩 상태일 때 대체 렌더링을 눈으로 보고싶어서 넣었습니다)
