### PR TITLE
[FE] fix: 빈 공간 클릭 시 이동되게 수정

### DIFF
--- a/frontend/src/components/Category/Category/Category.tsx
+++ b/frontend/src/components/Category/Category/Category.tsx
@@ -53,7 +53,7 @@ const Category = ({ categoryId, categoryName, isDefaultCategory }: Props) => {
   };
 
   return (
-    <S.Container>
+    <S.Container $isDefaultCategory={isDefaultCategory}>
       {isInputOpen ? (
         <Input
           type='text'
@@ -95,7 +95,7 @@ const Category = ({ categoryId, categoryName, isDefaultCategory }: Props) => {
 export default Category;
 
 const S = {
-  Container: styled.div`
+  Container: styled.div<{ $isDefaultCategory: boolean }>`
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -105,9 +105,12 @@ const S = {
     font-size: 1.4rem;
 
     &:hover {
+      & > button {
+        padding-right: ${({ $isDefaultCategory }) => !$isDefaultCategory && '4rem'};
+      }
+
       div {
-        display: inline-flex;
-        gap: 0.4rem;
+        opacity: 0.99;
       }
     }
   `,
@@ -140,8 +143,11 @@ const S = {
   `,
 
   IconContainer: styled.div`
-    display: none;
-    margin-right: 0.4rem;
+    display: flex;
+    position: absolute;
+    right: 0;
+    margin-right: 0.8rem;
+    opacity: 0;
   `,
 
   Button: styled.button`

--- a/frontend/src/components/Category/WritingList/WritingList.tsx
+++ b/frontend/src/components/Category/WritingList/WritingList.tsx
@@ -100,7 +100,7 @@ const S = {
       background-color: ${({ theme }) => theme.color.gray3};
 
       & > button {
-        padding-right: 3rem;
+        padding-right: 2.8rem;
       }
 
       div {

--- a/frontend/src/components/Category/WritingList/WritingList.tsx
+++ b/frontend/src/components/Category/WritingList/WritingList.tsx
@@ -99,9 +99,12 @@ const S = {
     &:hover {
       background-color: ${({ theme }) => theme.color.gray3};
 
+      & > button {
+        padding-right: 3rem;
+      }
+
       div {
-        display: flex;
-        flex-shrink: 0;
+        opacity: 0.99;
       }
     }
   `,
@@ -110,6 +113,7 @@ const S = {
     display: flex;
     align-items: center;
     gap: 0.4rem;
+    width: 100%;
     min-width: 0;
     height: 100%;
     padding: 0.4rem 0 0.4rem 3.2rem;
@@ -138,8 +142,10 @@ const S = {
   `,
 
   DeleteButtonWrapper: styled.div`
-    display: none;
+    position: absolute;
+    right: 0;
     margin-right: 0.8rem;
+    opacity: 0;
   `,
 
   DragLastSection: styled.div<{ $isDragOverTarget: boolean }>`

--- a/frontend/src/components/TrashCan/DeletedWritingList.tsx
+++ b/frontend/src/components/TrashCan/DeletedWritingList.tsx
@@ -12,7 +12,7 @@ const DeletedWritingList = () => {
   const { goWritingPage } = usePageNavigate();
   const activeWritingInfo = useGlobalStateValue(activeWritingInfoState);
   const writingId = activeWritingInfo?.id;
-  const deletePermanentWritings = useDeletePermanentWritings();
+  const deletePermanentWritings = useDeletePermanentWritings(() => {});
 
   if (!writingId) return;
   if (!deletedWritings || deletedWritings?.length === 0)

--- a/frontend/src/components/TrashCanTable/TrashCanTable.tsx
+++ b/frontend/src/components/TrashCanTable/TrashCanTable.tsx
@@ -43,8 +43,7 @@ const TrashCanTable = ({ writings }: Props) => {
                 variant='unstyled'
                 type='checkbox'
                 checked={isAllCheckboxClicked}
-                defaultChecked={false}
-                onClick={toggleAllCheckbox}
+                onChange={toggleAllCheckbox}
               />
             </th>
             <th>글 제목</th>
@@ -58,7 +57,6 @@ const TrashCanTable = ({ writings }: Props) => {
                   variant='unstyled'
                   type='checkbox'
                   checked={getIsChecked(id)}
-                  defaultChecked={false}
                   onChange={() => toggleCheckbox(id)}
                 />
               </td>

--- a/frontend/src/components/TrashCanTable/TrashCanTable.tsx
+++ b/frontend/src/components/TrashCanTable/TrashCanTable.tsx
@@ -43,6 +43,7 @@ const TrashCanTable = ({ writings }: Props) => {
                 variant='unstyled'
                 type='checkbox'
                 checked={isAllCheckboxClicked}
+                defaultChecked={false}
                 onClick={toggleAllCheckbox}
               />
             </th>
@@ -57,6 +58,7 @@ const TrashCanTable = ({ writings }: Props) => {
                   variant='unstyled'
                   type='checkbox'
                   checked={getIsChecked(id)}
+                  defaultChecked={false}
                   onChange={() => toggleCheckbox(id)}
                 />
               </td>

--- a/frontend/src/components/TrashCanTable/TrashCanTable.tsx
+++ b/frontend/src/components/TrashCanTable/TrashCanTable.tsx
@@ -42,7 +42,7 @@ const TrashCanTable = ({ writings }: Props) => {
               <Input
                 variant='unstyled'
                 type='checkbox'
-                defaultChecked={isAllCheckboxClicked}
+                checked={isAllCheckboxClicked}
                 onClick={toggleAllCheckbox}
               />
             </th>
@@ -56,7 +56,7 @@ const TrashCanTable = ({ writings }: Props) => {
                 <Input
                   variant='unstyled'
                   type='checkbox'
-                  defaultChecked={getIsChecked(id)}
+                  checked={getIsChecked(id)}
                   onChange={() => toggleCheckbox(id)}
                 />
               </td>

--- a/frontend/src/components/TrashCanTable/useDeletePermanentWritings.ts
+++ b/frontend/src/components/TrashCanTable/useDeletePermanentWritings.ts
@@ -3,12 +3,13 @@ import { deletePermanentWritings as deletePermanentWritingsAPI } from 'apis/tras
 import { useToast } from 'hooks/@common/useToast';
 import { HttpError } from 'utils/apis/HttpError';
 
-export const useDeletePermanentWritings = () => {
+export const useDeletePermanentWritings = (onSuccessCbFn: () => void) => {
   const queryClient = useQueryClient();
   const toast = useToast();
   const { mutate } = useMutation(deletePermanentWritingsAPI, {
     onSuccess: () => {
       toast.show({ type: 'success', message: '글이 삭제되었습니다.' });
+      onSuccessCbFn();
       queryClient.invalidateQueries(['deletedWritings']);
     },
     onError: (error) => {

--- a/frontend/src/components/TrashCanTable/useRestoreDeletedWritings.ts
+++ b/frontend/src/components/TrashCanTable/useRestoreDeletedWritings.ts
@@ -3,12 +3,13 @@ import { restoreDeletedWritings as restoreDeletedWritingsAPI } from 'apis/trash'
 import { useToast } from 'hooks/@common/useToast';
 import { HttpError } from 'utils/apis/HttpError';
 
-export const useRestoreDeleteWritings = () => {
+export const useRestoreDeleteWritings = (onSuccessCbFn: () => void) => {
   const queryClient = useQueryClient();
   const toast = useToast();
   const { mutate } = useMutation(restoreDeletedWritingsAPI, {
     onSuccess: () => {
       toast.show({ type: 'success', message: '글이 복구되었습니다.' });
+      onSuccessCbFn();
       queryClient.invalidateQueries(['deletedWritings']);
     },
     onError: (error) => {

--- a/frontend/src/components/TrashCanTable/useTrashCanTable.ts
+++ b/frontend/src/components/TrashCanTable/useTrashCanTable.ts
@@ -7,8 +7,14 @@ export const useTrashCanTable = (writings: DeletedWriting[]) => {
   const [writingIds, setWritingIds] = useState<number[]>([]);
   const [isAllCheckboxClicked, setIsAllAllCheckboxClicked] = useState(false);
   const rowRef = useRef<HTMLTableRowElement>(null);
-  const deletePermanentWritingsMutation = useDeletePermanentWritings();
-  const restoreDeletedWritingsMutation = useRestoreDeleteWritings();
+  const deletePermanentWritingsMutation = useDeletePermanentWritings(() => {
+    setWritingIds([]);
+    setIsAllAllCheckboxClicked(false);
+  });
+  const restoreDeletedWritingsMutation = useRestoreDeleteWritings(() => {
+    setWritingIds([]);
+    setIsAllAllCheckboxClicked(false);
+  });
 
   useEffect(() => {
     rowRef.current?.focus();


### PR DESCRIPTION
### 🛠️ Issue

- close #522 

### ✅ Tasks
- [x] 카테고리 내부 글 목록 빈 공간 클릭 시 이동되게 수정
- [x] 카테고리 빈 공간 클릭 시 이동되게 수정

### ⏰ Time Difference
- 0.5 -> 1

### 📝 Note
reflow repaint를 피하기 위해
이전에 호버하면 display: none 이 display: flex 로 변경되는 부분을 opacity: 0 -> opacity: 0.99로 수정했습니다.
또한 position도 absolute로 수정했습니다~!

https://github.com/woowacourse-teams/2023-dong-gle/assets/64737872/1966425c-b31e-4be6-8def-b44c5e9667b1

