### PR TITLE
[FE] fix: 빈 공간 클릭 시 이동되게 수정

### DIFF
--- a/frontend/src/components/Category/Category/Category.tsx
+++ b/frontend/src/components/Category/Category/Category.tsx
@@ -53,7 +53,7 @@ const Category = ({ categoryId, categoryName, isDefaultCategory }: Props) => {
   };
 
   return (
-    <S.Container>
+    <S.Container $isDefaultCategory={isDefaultCategory}>
       {isInputOpen ? (
         <Input
           type='text'
@@ -96,7 +96,7 @@ const Category = ({ categoryId, categoryName, isDefaultCategory }: Props) => {
 export default Category;
 
 const S = {
-  Container: styled.div`
+  Container: styled.div<{ $isDefaultCategory: boolean }>`
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -106,9 +106,12 @@ const S = {
     font-size: 1.4rem;
 
     &:hover {
+      & > button {
+        padding-right: ${({ $isDefaultCategory }) => !$isDefaultCategory && '4rem'};
+      }
+
       div {
-        display: inline-flex;
-        gap: 0.4rem;
+        opacity: 0.99;
       }
     }
   `,
@@ -141,8 +144,11 @@ const S = {
   `,
 
   IconContainer: styled.div`
-    display: none;
-    margin-right: 0.4rem;
+    display: flex;
+    position: absolute;
+    right: 0;
+    margin-right: 0.8rem;
+    opacity: 0;
   `,
 
   Button: styled.button`

--- a/frontend/src/components/Category/Category/Category.tsx
+++ b/frontend/src/components/Category/Category/Category.tsx
@@ -107,7 +107,7 @@ const S = {
 
     &:hover {
       & > button {
-        padding-right: ${({ $isDefaultCategory }) => !$isDefaultCategory && '4rem'};
+        padding-right: ${({ $isDefaultCategory }) => !$isDefaultCategory && '5.2rem'};
       }
 
       div {

--- a/frontend/src/components/Category/WritingList/WritingList.tsx
+++ b/frontend/src/components/Category/WritingList/WritingList.tsx
@@ -99,9 +99,12 @@ const S = {
     &:hover {
       background-color: ${({ theme }) => theme.color.gray3};
 
+      & > button {
+        padding-right: 2.8rem;
+      }
+
       div {
-        display: flex;
-        flex-shrink: 0;
+        opacity: 0.99;
       }
     }
   `,
@@ -138,8 +141,10 @@ const S = {
   `,
 
   DeleteButtonWrapper: styled.div`
-    display: none;
+    position: absolute;
+    right: 0;
     margin-right: 0.8rem;
+    opacity: 0;
   `,
 
   DragLastSection: styled.div<{ $isDragOverTarget: boolean }>`

--- a/frontend/src/components/Category/WritingList/WritingList.tsx
+++ b/frontend/src/components/Category/WritingList/WritingList.tsx
@@ -113,6 +113,7 @@ const S = {
     display: flex;
     align-items: center;
     gap: 0.4rem;
+    width: 100%;
     min-width: 0;
     height: 100%;
     padding: 0.4rem 0 0.4rem 3.2rem;


### PR DESCRIPTION
### 🛠️ Issue

- close #522 

### ✅ Tasks
- [x] 카테고리 내부 글 목록 빈 공간 클릭 시 이동되게 수정
- [x] 카테고리 빈 공간 클릭 시 이동되게 수정

### ⏰ Time Difference
- 0.5 -> 1

### 📝 Note
reflow repaint를 피하기 위해
이전에 호버하면 display: none 이 display: flex 로 변경되는 부분을 opacity: 0 -> opacity: 0.99로 수정했습니다.
또한 position도 absolute로 수정했습니다~!

https://github.com/woowacourse-teams/2023-dong-gle/assets/64737872/1966425c-b31e-4be6-8def-b44c5e9667b1

