### PR TITLE
[FE] fix: `prismjs` dynamic import 방식 개선

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "@types/styled-components": "5.1.26",
     "@typescript-eslint/eslint-plugin": "5.61.0",
     "@typescript-eslint/parser": "5.61.0",
+    "copy-webpack-plugin": "^11.0.0",
     "cross-env": "^7.0.3",
     "css-loader": "^6.8.1",
     "cypress": "^12.17.3",

--- a/frontend/src/hooks/@common/useCodeHighlight.ts
+++ b/frontend/src/hooks/@common/useCodeHighlight.ts
@@ -1,27 +1,20 @@
 import { useEffect } from 'react';
 import Prism from 'prismjs';
 import 'prismjs/themes/prism.css';
+import 'prismjs/plugins/autoloader/prism-autoloader.js';
 
-const prismLanguageFromCodeTagRegex = /<code class="language-(\w+)">/g;
+// webpack copyWebpackPlugin 이용해 prismjs/components/경로에 언어모듈 저장
+Prism.plugins.autoloader.languages_path = '/prismjs/components/';
 
 const useCodeHighlight = (htmlDOMString?: string) => {
   useEffect(() => {
     if (!htmlDOMString) return;
-    const importPrism = async () => {
-      const languages = Array.from(htmlDOMString.matchAll(prismLanguageFromCodeTagRegex)).map(
-        (match) => match[1],
-      );
-
-      await Promise.all(
-        languages.map((language) => import(`prismjs/components/prism-${language}`)),
-      );
-    };
 
     const highlightCode = () => {
       Prism.highlightAll();
     };
 
-    importPrism().then(highlightCode);
+    highlightCode();
   }, [htmlDOMString]);
 };
 

--- a/frontend/src/mocks/data/writingPage.ts
+++ b/frontend/src/mocks/data/writingPage.ts
@@ -1,7 +1,146 @@
 import { GetWritingPropertiesResponse } from 'types/apis/writings';
 
 const writingContentMock = `
-<h1>동글이란?</h1><h2>블로그 글 관리의 새로운 해결책</h2><p><code>노션</code> 같은 <strong><em>텍스트 에디터</strong></em> 에서 작성한 글을 블로그에 올린 적이 있으신가요?</p><p>직접 글을 블로그로 올리다보면 그 과정이 귀찮아지고 어떤 글을 옮겼는지 헷갈릴 때가 많습니다.</p><p>이 문제를 해결하기 위해 우리는 <a href=\"https://donggle.blog/\"><strong>동글</strong></a> 서비스를 만들었습니다.</p><h3>주요 기능</h3><ol><li><strong>노션 글 업로드</strong>: 노션에 작성한 글을 간편하게 동글에 업로드할 수 있습니다. (마크다운 파일 업로드도 지원)</li><li><strong>카테고리 분류</strong>: 동글은 업로드한 글을 카테고리로 분류하여 모아볼 수 있는 기능을 제공합니다.</li><li><strong>다양한 블로그 플랫폼 지원</strong>: 작성한 글을 <code>Tistory</code>나 <code>Medium</code>와 같은 블로그 플랫폼에 발행할 수 있습니다.</li><li><strong>발행 정보 투명화</strong>: 글의 작성 일자와 발행된 블로그 정보를 통해 글을 효율적으로 관리할 수 있습니다.</li></ol><p>다양한 곳에서 글을 작성 후 쉽게 블로그로 포스팅하고 싶은 분들은 <strong>동글</strong>의 도움을 받아보세요.</p><p>더 많은 시간과 에너지를 여러분의 글 작성과 이야기에 투자할 수 있을 것입니다.</p><blockquote><a href=\"https://www.donggle.blog/\"><strong>동글</strong></a>과 함께라면 블로그 글 관리는 더 이상 고민거리가 아닙니다.</blockquote><p>이제 글 작성에 더 집중하며, 블로그 관리에 소비되는 시간과 에너지를 절약하세요!</p>`;
+<h1>동글이란?</h1><h2>블로그 글 관리의 새로운 해결책</h2><p><code>노션</code> 같은 <strong><em>텍스트 에디터</strong></em> 에서 작성한 글을 블로그에 올린 적이 있으신가요?</p><p>직접 글을 블로그로 올리다보면 그 과정이 귀찮아지고 어떤 글을 옮겼는지 헷갈릴 때가 많습니다.</p><p>이 문제를 해결하기 위해 우리는 <a href=\"https://donggle.blog/\"><strong>동글</strong></a> 서비스를 만들었습니다.</p><h3>주요 기능</h3><ol><li><strong>노션 글 업로드</strong>: 노션에 작성한 글을 간편하게 동글에 업로드할 수 있습니다. (마크다운 파일 업로드도 지원)</li><li><strong>카테고리 분류</strong>: 동글은 업로드한 글을 카테고리로 분류하여 모아볼 수 있는 기능을 제공합니다.</li><li><strong>다양한 블로그 플랫폼 지원</strong>: 작성한 글을 <code>Tistory</code>나 <code>Medium</code>와 같은 블로그 플랫폼에 발행할 수 있습니다.</li><li><strong>발행 정보 투명화</strong>: 글의 작성 일자와 발행된 블로그 정보를 통해 글을 효율적으로 관리할 수 있습니다.</li></ol><p>다양한 곳에서 글을 작성 후 쉽게 블로그로 포스팅하고 싶은 분들은 <strong>동글</strong>의 도움을 받아보세요.</p><p>더 많은 시간과 에너지를 여러분의 글 작성과 이야기에 투자할 수 있을 것입니다.</p><blockquote><a href=\"https://www.donggle.blog/\"><strong>동글</strong></a>과 함께라면 블로그 글 관리는 더 이상 고민거리가 아닙니다.</blockquote><p>이제 글 작성에 더 집중하며, 블로그 관리에 소비되는 시간과 에너지를 절약하세요!</p><pre><code class="language-javascript">
+function helloWorld() {
+  console.log("Hello, World!");
+}
+<pre><code class="language-html">
+&lt;!DOCTYPE html&gt;
+&lt;html lang="en"&gt;
+&lt;head&gt;
+    &lt;meta charset="UTF-8"&gt;
+    &lt;meta name="viewport" content="width=device-width, initial-scale=1.0"&gt;
+    &lt;title&gt;Hello World&lt;/title&gt;
+&lt;/head&gt;
+&lt;body&gt;
+    &lt;h1&gt;Hello, World!&lt;/h1&gt;
+&lt;/body&gt;
+&lt;/html&gt;
+</code></pre>
+
+</code></pre>
+<pre><code class="language-python">
+def hello_world():
+    print("Hello, World!")
+</code></pre>
+<pre><code class="language-java">
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}
+</code></pre>
+<pre><code class="language-csharp">
+public class HelloWorld {
+    public static void Main(string[] args) {
+        Console.WriteLine("Hello, World!");
+    }
+}
+</code></pre>
+<pre><code class="language-ruby">
+def hello_world
+  puts "Hello, World!"
+end
+</code></pre>
+<pre><code class="language-php">
+&lt;?php
+function helloWorld() {
+  echo "Hello, World!";
+}
+?&gt;
+</code></pre>
+<pre><code class="language-go">
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, World!")
+}
+</code></pre>
+<pre><code class="language-typescript">
+function helloWorld(): void {
+  console.log("Hello, World!");
+}
+</code></pre>
+<pre><code class="language-swift">
+func helloWorld() {
+    print("Hello, World!")
+}
+</code></pre>
+<pre><code class="language-cpp">
+#include &lt;iostream&gt;
+
+int main() {
+    std::cout << "Hello, World!" << std::endl;
+    return 0;
+}
+</code></pre>
+<pre><code class="language-rust">
+fn main() {
+    println!("Hello, World!");
+}
+</code></pre>
+<pre><code class="language-kotlin">
+fun main() {
+    println("Hello, World!")
+}
+</code></pre>
+<pre><code class="language-perl">
+print "Hello, World!\n";
+</code></pre>
+<pre><code class="language-sql">
+SELECT 'Hello, World!' AS greeting;
+</code></pre>
+<pre><code class="language-haskell">
+main :: IO ()
+main = putStrLn "Hello, World!"
+</code></pre>
+<pre><code class="language-lua">
+print("Hello, World!")
+</code></pre>
+<pre><code class="language-bash">
+echo "Hello, World!"
+</code></pre>
+<pre><code class="language-matlab">
+disp('Hello, World!');
+</code></pre>
+<pre><code class="language-scala">
+object HelloWorld {
+  def main(args: Array[String]): Unit = {
+    println("Hello, World!")
+  }
+}
+</code></pre>
+<pre><code class="language-groovy">
+println 'Hello, World!'
+</code></pre>
+<pre><code class="language-r">
+print("Hello, World!")
+</code></pre>
+<pre><code class="language-fortran">
+PROGRAM HelloWorld
+   PRINT *, 'Hello, World!'
+END PROGRAM HelloWorld
+</code></pre>
+<pre><code class="language-pascal">
+program HelloWorld;
+begin
+  writeln('Hello, World!');
+end.
+</code></pre>
+<pre><code class="language-elixir">
+IO.puts "Hello, World!"
+</code></pre>
+<pre><code class="language-prolog">
+hello_world :- write('Hello, World!'), nl.
+</code></pre>
+<pre><code class="language-lisp">
+(print "Hello, World!")
+</code></pre>
+
+`;
 
 export const writing = {
   id: 1,

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   mode: process.env.NODE_ENV === 'development' ? 'development' : 'production',
@@ -69,6 +70,9 @@ module.exports = {
       openAnalyzer: false,
       generateStatsFile: true,
       statsFilename: 'bundle-report.json',
+    }),
+    new CopyPlugin({
+      patterns: [{ from: 'node_modules/prismjs/components/', to: 'prismjs/components/' }],
     }),
   ],
   devServer: {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5242,6 +5242,18 @@ copy-anything@^3.0.2:
   dependencies:
     is-what "^4.1.8"
 
+copy-webpack-plugin@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz#96d4dbdb5f73d02dd72d0528d1958721ab72e04a"
+  integrity sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==
+  dependencies:
+    fast-glob "^3.2.11"
+    glob-parent "^6.0.1"
+    globby "^13.1.1"
+    normalize-path "^3.0.0"
+    schema-utils "^4.0.0"
+    serialize-javascript "^6.0.0"
+
 core-js-compat@^3.25.1:
   version "3.31.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.31.1.tgz#5084ad1a46858df50ff89ace152441a63ba7aae0"
@@ -6572,6 +6584,17 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-glob@^3.2.11:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.0.tgz#7c40cb491e1e2ed5664749e87bfb516dbe8727c0"
@@ -7041,7 +7064,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.2:
+glob-parent@^6.0.1, glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -7121,7 +7144,7 @@ globby@^11.0.1, globby@^11.0.2, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-globby@^13.1.3:
+globby@^13.1.1, globby@^13.1.3:
   version "13.2.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-13.2.2.tgz#63b90b1bf68619c2135475cbd4e71e66aa090592"
   integrity sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==
@@ -10452,7 +10475,7 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@^6.0.1:
+serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
   integrity sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==


### PR DESCRIPTION
### 🛠️ Issue

- close #549

### ✅ Tasks
- `prismjs` 동적 import 방식을 개선
- `prismjs`의 [autoloader](https://prismjs.com/plugins/autoloader/) 이용
-  `autoloader` 에게 알려줄 `prismjs/components`(언어 스타일링 패키지)를 따로 빼서 번들링하기 위해 `copyWebpackPlugin`을 이용

### ⏰ Time Difference
- 4 + 4

### 📝 Note
- 흠.. 생각보다 어려웠네요.
- 이제 코드블럭에서 약 300개의 언어를 지원합니다!
