### PR TITLE
[BE] fix: 티스토리 카테고리가 없는 사용자에 대한 예외 처리 기능 구현

### DIFF
--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
@@ -20,7 +20,7 @@ import org.donggle.backend.infrastructure.client.tistory.dto.response.TistoryCat
 import org.donggle.backend.infrastructure.client.tistory.dto.response.TistoryGetWritingResponseWrapper;
 import org.donggle.backend.infrastructure.client.tistory.dto.response.TistoryPublishWritingResponseWrapper;
 import org.donggle.backend.ui.response.PublishResponse;
-import org.donggle.backend.ui.response.TistoryCategoryListResposne;
+import org.donggle.backend.ui.response.TistoryCategoryListResponse;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -114,7 +114,7 @@ public class TistoryApiClient implements BlogClient {
                 .build();
     }
 
-    public TistoryCategoryListResposne findCategory(final Long memberId) {
+    public TistoryCategoryListResponse findCategory(final Long memberId) {
         final MemberCredentials memberCredentials = getMemberCredentials(memberId);
         final String categoryListUri = UriComponentsBuilder.fromUriString("/category/list")
                 .queryParam("access_token", memberCredentials.getTistoryToken())
@@ -132,11 +132,11 @@ public class TistoryApiClient implements BlogClient {
                 .block();
         final List<TistoryCategoryResponse> categories = categoryList.tistory().item().categories();
         if (Objects.isNull(categories)) {
-            return new TistoryCategoryListResposne(Collections.emptyList());
+            return new TistoryCategoryListResponse(Collections.emptyList());
         }
-        return new TistoryCategoryListResposne(
+        return new TistoryCategoryListResponse(
                 categories.stream()
-                        .map(category -> new TistoryCategoryListResposne.TistoryCategoryResponse(category.id(), category.name()))
+                        .map(category -> new TistoryCategoryListResponse.TistoryCategoryResponse(category.id(), category.name()))
                         .toList());
     }
 

--- a/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
+++ b/backend/src/main/java/org/donggle/backend/infrastructure/client/tistory/TistoryApiClient.java
@@ -16,6 +16,7 @@ import org.donggle.backend.infrastructure.client.tistory.dto.request.TistoryPubl
 import org.donggle.backend.infrastructure.client.tistory.dto.request.TistoryPublishRequest;
 import org.donggle.backend.infrastructure.client.tistory.dto.response.TistoryBlogNameResponse;
 import org.donggle.backend.infrastructure.client.tistory.dto.response.TistoryCategoryListResponseWrapper;
+import org.donggle.backend.infrastructure.client.tistory.dto.response.TistoryCategoryListResponseWrapper.TistoryCategoryListResponse.TistoryCategoryResponse;
 import org.donggle.backend.infrastructure.client.tistory.dto.response.TistoryGetWritingResponseWrapper;
 import org.donggle.backend.infrastructure.client.tistory.dto.response.TistoryPublishWritingResponseWrapper;
 import org.donggle.backend.ui.response.PublishResponse;
@@ -29,8 +30,11 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import static org.donggle.backend.domain.blog.BlogType.TISTORY;
 import static org.donggle.backend.infrastructure.client.exception.ClientException.handle4xxException;
@@ -126,8 +130,12 @@ public class TistoryApiClient implements BlogClient {
                         .map(e -> new ClientInternalServerError(PLATFORM_NAME)))
                 .bodyToMono(TistoryCategoryListResponseWrapper.class)
                 .block();
+        final List<TistoryCategoryResponse> categories = categoryList.tistory().item().categories();
+        if (Objects.isNull(categories)) {
+            return new TistoryCategoryListResposne(Collections.emptyList());
+        }
         return new TistoryCategoryListResposne(
-                categoryList.tistory().item().categories().stream()
+                categories.stream()
                         .map(category -> new TistoryCategoryListResposne.TistoryCategoryResponse(category.id(), category.name()))
                         .toList());
     }

--- a/backend/src/main/java/org/donggle/backend/ui/BlogController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/BlogController.java
@@ -3,7 +3,7 @@ package org.donggle.backend.ui;
 import lombok.RequiredArgsConstructor;
 import org.donggle.backend.infrastructure.client.tistory.TistoryApiClient;
 import org.donggle.backend.ui.common.AuthenticationPrincipal;
-import org.donggle.backend.ui.response.TistoryCategoryListResposne;
+import org.donggle.backend.ui.response.TistoryCategoryListResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,10 +16,10 @@ public class BlogController {
     private final TistoryApiClient tistoryApiService;
 
     @GetMapping("/tistory/category")
-    public ResponseEntity<TistoryCategoryListResposne> tistoryCategoryList(
+    public ResponseEntity<TistoryCategoryListResponse> tistoryCategoryList(
             @AuthenticationPrincipal final Long memberId
     ) {
-        final TistoryCategoryListResposne response = tistoryApiService.findCategory(memberId);
+        final TistoryCategoryListResponse response = tistoryApiService.findCategory(memberId);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/org/donggle/backend/ui/response/TistoryCategoryListResponse.java
+++ b/backend/src/main/java/org/donggle/backend/ui/response/TistoryCategoryListResponse.java
@@ -2,7 +2,7 @@ package org.donggle.backend.ui.response;
 
 import java.util.List;
 
-public record TistoryCategoryListResposne(
+public record TistoryCategoryListResponse(
         List<TistoryCategoryResponse> categories
 ) {
     public record TistoryCategoryResponse(


### PR DESCRIPTION
### 🛠️ Issue

- close #551 

### ✅ Tasks
- [x]  티스토리에 카테고리가 없는 사용자에 대한 예외 로직 추가

### ⏰ Time Difference
- 0

