### PR TITLE
[BE] fix: `CategoryService`의 `modifyCategoryOrder`에서 `flush()` 호출 추가

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/service/category/CategoryService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/category/CategoryService.java
@@ -197,7 +197,7 @@ public class CategoryService {
         source.changeNextCategoryNull();
         final Category preCategory = findPreCategory(source.getId());
         preCategory.changeNextCategory(nextCategory);
-
+        categoryRepository.flush();
         if (targetCategoryId == LAST_CATEGORY_FLAG) {
             lastCategory.changeNextCategory(source);
         } else {


### PR DESCRIPTION
### 🛠️ Issue

- close #557 

### ✅ Tasks
- `CategoryService`의 `modifyCategoryOrder` 메서드에 `flush()` 호출 추가

### ⏰ Time Difference
- 0.1 -> 0.1

### 📝 Note
- 
