### PR TITLE
[FE] design: reset.css 에 a:link, a:visit 컬러 스타일 추가

### DIFF
--- a/frontend/src/components/GoToPageLink/GoToPageLink.tsx
+++ b/frontend/src/components/GoToPageLink/GoToPageLink.tsx
@@ -34,9 +34,5 @@ const S = {
     &:hover {
       background-color: ${({ theme }) => theme.color.gray3};
     }
-
-    &:visited {
-      color: ${({ theme }) => theme.color.gray13};
-    }
   `,
 };

--- a/frontend/src/styles/reset.ts
+++ b/frontend/src/styles/reset.ts
@@ -21,6 +21,14 @@ export const reset = css`
 
   a {
     text-decoration: none;
+
+    &:link {
+      color: #000000;
+    }
+
+    &:visited {
+      color: #000000;
+    }
   }
 
   button {


### PR DESCRIPTION
### 🛠️ Issue

- close #565 

### ✅ Tasks
- [x] reset.css 에 a:link, a:visit 에 검정색으로 설정

### ⏰ Time Difference
- 0.5 -> 0.5

### 📝 Note
- 변경 전
<img width="315" alt="스크린샷 2023-10-06 오후 6 19 57" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/64737872/ffe2f2a6-1643-43f5-ad5e-ba3f3b7c2c01">

- 변경 후
<img width="287" alt="스크린샷 2023-10-06 오후 6 20 22" src="https://github.com/woowacourse-teams/2023-dong-gle/assets/64737872/4ba93829-0e1f-4495-9961-6412f984d0a1">
