### PR TITLE
[BE] refactor: logout 및 reissueRefreshToken 요청시 리프래시 토큰이 없는 경우 추가 핸들링

### DIFF
--- a/backend/src/main/java/org/donggle/backend/application/service/auth/AuthFacadeService.java
+++ b/backend/src/main/java/org/donggle/backend/application/service/auth/AuthFacadeService.java
@@ -2,6 +2,7 @@ package org.donggle.backend.application.service.auth;
 
 import lombok.RequiredArgsConstructor;
 import org.donggle.backend.application.service.request.OAuthAccessTokenRequest;
+import org.donggle.backend.domain.auth.JwtTokenProvider;
 import org.donggle.backend.domain.oauth.SocialType;
 import org.donggle.backend.infrastructure.oauth.kakao.dto.response.UserInfo;
 import org.donggle.backend.ui.response.TokenResponse;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 public class AuthFacadeService {
     private final LoginClients oauthClients;
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public String createAuthorizeRedirectUri(final String socialType, final String redirect_uri) {
         return oauthClients.redirectUri(SocialType.from(socialType), redirect_uri);
@@ -26,7 +28,8 @@ public class AuthFacadeService {
         return authService.login(socialUserInfo, type);
     }
 
-    public void logout(final Long memberId) {
+    public void logout(final String refreshToken) {
+        final Long memberId = jwtTokenProvider.getPayload(refreshToken);
         authService.logout(memberId);
     }
 

--- a/backend/src/main/java/org/donggle/backend/exception/authentication/ExpiredRefreshTokenException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/authentication/ExpiredRefreshTokenException.java
@@ -1,7 +1,8 @@
 package org.donggle.backend.exception.authentication;
 
 public class ExpiredRefreshTokenException extends UnAuthenticationException {
-    private static final String MESSAGE = "유효하지 않은 토큰입니다.";
+    private static final String MESSAGE = "토큰이 만료되었습니다.";
+    private static final int LOGIN_REQUEST_CODE = 4012;
 
     public ExpiredRefreshTokenException() {
         super(MESSAGE);
@@ -10,5 +11,10 @@ public class ExpiredRefreshTokenException extends UnAuthenticationException {
     @Override
     public String getHint() {
         return "RefreshToken이 만료되었습니다. 다시 로그인을 진행하세요.";
+    }
+
+    @Override
+    public int getErrorCode() {
+        return LOGIN_REQUEST_CODE;
     }
 }

--- a/backend/src/main/java/org/donggle/backend/exception/authentication/InvalidRefreshTokenException.java
+++ b/backend/src/main/java/org/donggle/backend/exception/authentication/InvalidRefreshTokenException.java
@@ -8,7 +8,7 @@ public class InvalidRefreshTokenException extends UnAuthenticationException {
     }
 
     public InvalidRefreshTokenException(final Throwable cause) {
-        super(null, cause);
+        super(MESSAGE, cause);
     }
 
     @Override

--- a/backend/src/main/java/org/donggle/backend/ui/AuthController.java
+++ b/backend/src/main/java/org/donggle/backend/ui/AuthController.java
@@ -71,15 +71,19 @@ public class AuthController {
 
     @PostMapping("/token/refresh")
     public ResponseEntity<AccessTokenResponse> reissueAccessToken(@CookieValue(required = false) final String refreshToken) {
-        if (Objects.isNull(refreshToken)) {
-            throw new ExpiredRefreshTokenException();
-        }
+        validateRefreshToken(refreshToken);
         final TokenResponse response = authFacadeService.reissueAccessTokenAndRefreshToken(refreshToken);
         final ResponseCookie cookie = createRefreshTokenCookie(response.refreshToken());
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .header("Set-Cookie", cookie.toString())
                 .body(new AccessTokenResponse(response.accessToken()));
+    }
+
+    private void validateRefreshToken(final String refreshToken) {
+        if (Objects.isNull(refreshToken)) {
+            throw new ExpiredRefreshTokenException();
+        }
     }
 
     private ResponseCookie createRefreshTokenCookie(final String refreshToken) {

--- a/backend/src/main/java/org/donggle/backend/ui/common/WebMvcConfig.java
+++ b/backend/src/main/java/org/donggle/backend/ui/common/WebMvcConfig.java
@@ -25,7 +25,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
         registry.addInterceptor(new AuthInterceptor(jwtTokenProvider))
                 .addPathPatterns("/member/**", "/writings/**", "/categories/**", "/trash/**", "/connections/**", "/auth/**")
-                .excludePathPatterns("/connections/**/redirect", "/auth/login/**", "/auth/token/refresh")
+                .excludePathPatterns("/connections/**/redirect", "/auth/login/**", "/auth/token/refresh", "/auth/logout")
                 .order(2);
     }
 

--- a/backend/src/test/java/org/donggle/backend/application/service/auth/AuthFacadeServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/auth/AuthFacadeServiceTest.java
@@ -1,6 +1,7 @@
 package org.donggle.backend.application.service.auth;
 
 import org.donggle.backend.application.service.request.OAuthAccessTokenRequest;
+import org.donggle.backend.domain.auth.JwtTokenProvider;
 import org.donggle.backend.domain.oauth.SocialType;
 import org.donggle.backend.infrastructure.oauth.kakao.dto.response.UserInfo;
 import org.donggle.backend.ui.response.TokenResponse;
@@ -26,6 +27,8 @@ class AuthFacadeServiceTest {
     private LoginClients oauthClients;
     @Mock
     private AuthService authService;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
     @InjectMocks
     private AuthFacadeService authFacadeService;
 
@@ -69,13 +72,13 @@ class AuthFacadeServiceTest {
     @DisplayName("logout 메서드 테스트")
     void testLogout() {
         // given
-        final Long memberId = 1L;
+        given(jwtTokenProvider.getPayload(anyString())).willReturn(1L);
 
         // when
-        authFacadeService.logout(memberId);
+        authFacadeService.logout("validRefreshToken");
 
         // then
-        then(authService).should(times(1)).logout(memberId);
+        then(authService).should(times(1)).logout(1L);
     }
 
     @Test

--- a/backend/src/test/java/org/donggle/backend/ui/AuthControllerTest.java
+++ b/backend/src/test/java/org/donggle/backend/ui/AuthControllerTest.java
@@ -13,9 +13,9 @@ import org.springframework.http.MediaType;
 import java.util.Optional;
 
 import static org.donggle.backend.support.fix.MemberFixture.beaver_have_id;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -65,44 +65,62 @@ class AuthControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("로그아웃이 정상적으로 처리되면 200 상태를 반환한다.")
-    void logout() throws Exception {
+    void logout_with_refreshToken() throws Exception {
         //given
         final Long memberId = 1L;
-        final String accessToken = JwtSupporter.generateToken(memberId);
-        given(jwtTokenProvider.getPayload(accessToken)).willReturn(memberId);
-        //when
-        //then
+        final String refreshToken = JwtSupporter.generateToken(memberId);
+
+        //when, then
         mockMvc.perform(
                         post("/auth/logout")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header(AUTHORIZATION, "Bearer " + accessToken))
+                                .cookie(new Cookie("refreshToken", refreshToken))
+                )
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("쿠키에 리프레시 토큰이 없더라도, 로그아웃시 정상적으로 200 상태를 반환한다.")
+    void logout_without_refreshToken() throws Exception {
+        mockMvc.perform(
+                        post("/auth/logout").contentType(MediaType.APPLICATION_JSON)
+
+                )
                 .andExpect(status().isOk());
     }
 
     @Test
     @DisplayName("액세스 토큰 재발급이 정상적으로 처리되면 200 상태와 새로운 토큰을 반환한다.")
-    void reissueAccessToken() throws Exception {
+    void reissueAccessToken_with_refreshToken() throws Exception {
         //given
         final Long memberId = 1L;
-        final String accessToken = JwtSupporter.generateToken(memberId);
         final String refreshToken = JwtSupporter.generateToken(memberId);
-        final TokenResponse tokenResponse = new TokenResponse("access", "refresh");
+        final TokenResponse expectedResponse = new TokenResponse("access", "refresh");
         final Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
 
-        given(jwtTokenProvider.getPayload(accessToken)).willReturn(1L);
         given(tokenRepository.findByMemberId(memberId)).willReturn(Optional.of(new RefreshToken(refreshToken, beaver_have_id)));
-        given(authFacadeService.reissueAccessTokenAndRefreshToken(refreshToken)).willReturn(tokenResponse);
+        given(authFacadeService.reissueAccessTokenAndRefreshToken(refreshToken)).willReturn(expectedResponse);
 
-        //when
-        //then
+        //when, then
         mockMvc.perform(
                         post("/auth/token/refresh")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .header(AUTHORIZATION, "Bearer " + accessToken)
                                 .cookie(refreshTokenCookie)
                 )
                 .andExpect(status().isOk())
-                .andExpect(header().exists("Set-Cookie"))
-                .andExpect(jsonPath("$.accessToken").value(tokenResponse.accessToken()));
+                .andExpect(header().string("Set-Cookie", containsString("refreshToken=" + expectedResponse.refreshToken())))
+                .andExpect(jsonPath("$.accessToken").value(expectedResponse.accessToken()));
+    }
+
+    @Test
+    @DisplayName("리프래시 토큰이 만료되었을 때에는 예외가 발생한다.")
+    void reissueAccessToken_without_refreshToken() throws Exception {
+        mockMvc.perform(
+                        post("/auth/token/refresh").contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().is(401))
+                .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                .andExpect(jsonPath("$.error.hint").value("RefreshToken이 만료되었습니다. 다시 로그인을 진행하세요."))
+                .andExpect(jsonPath("$.error.code").value(4012));
     }
 }


### PR DESCRIPTION
### 🛠️ Issue

- close #562 

### ✅ Tasks
- 로그아웃 시 ArgumentResolver가 동작하지 않도록 수정
- 로그아웃 시 refreshToken이 없는 케이스 핸들링
- refreshTokn 재발급 요청시 refreshToken이 없는 케이스 핸들링

### ⏰ Time Difference
- 1 -> 1

### 📝 Note
