### PR TITLE
[ALL] chore: prod cicd actions 실행 순서 변경 및 deploy.sh 실행 추가

### DIFF
--- a/.github/workflows/build-be-prod.yml
+++ b/.github/workflows/build-be-prod.yml
@@ -1,11 +1,7 @@
 name: CICD for Backend Production
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "backend/**"
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -66,8 +62,3 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/dong-gle-backend-prod:latest
           platforms: linux/arm64
-
-  deploy:
-    needs: build
-    uses: ./.github/workflows/deploy-prod.yml
-    secrets: inherit

--- a/.github/workflows/build-fe-prod.yml
+++ b/.github/workflows/build-fe-prod.yml
@@ -1,11 +1,7 @@
-name: CICD for Frontend Production 
+name: CICD for Frontend Production
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'frontend/**'
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -19,15 +15,15 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
-          cache: 'yarn'
+          node-version: "18.x"
+          cache: "yarn"
           cache-dependency-path: ${{ vars.FE_DIRECTORY }}/yarn.lock
 
       - name: Install dependencies
         run: |
           yarn install --frozen-lockfile
         working-directory: ${{ vars.FE_DIRECTORY }}
-      
+
       - name: Create .env.production variable
         run: |
           touch .env.production
@@ -57,8 +53,3 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/dong-gle-frontend-prod:latest
           platforms: linux/arm64
-
-  deploy:
-    needs: build
-    uses: ./.github/workflows/deploy-prod.yml
-    secrets: inherit

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,3 +24,4 @@ jobs:
           sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           sudo chmod +x deploy.sh
           sudo ./deploy.sh ${{ vars.INFRA_PROFILE_DEVELOPMENT }}
+          sudo docker image prune -af

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,28 +1,35 @@
 name: Run Docker Compose Production
 
 on:
-  workflow_call:
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  fe-build:
+    uses: ./.github/workflows/build-fe-prod.yml
+    secrets: inherit
+
+  be-build:
+    uses: ./.github/workflows/build-be-prod.yml
+    secrets: inherit
+
   deploy:
-    runs-on: [self-hosted,prod]
+    runs-on: [self-hosted, prod]
+    needs: [fe-build, be-build]
     steps:
-    - uses: actions/checkout@v3
-    - name: create .env
-      run: |
-        touch .env
-        echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" >> .env
-        echo "SPRING_PROFILES_ACTIVE=${{ vars.SPRING_PROFILES_ACTIVE_PRODUCTION }}" >> .env
-        echo "INFRA_PROFILE=${{ vars.INFRA_PROFILE_PRODUCTION}}" >> .env
-    ## deploy to production
-    - name: Deploy to prod
-      run: |
-        sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-        sudo docker compose down
-        sudo docker compose pull
-        sudo docker compose up -d
-        sudo docker image prune -af
+      - uses: actions/checkout@v3
+      - name: create .env
+        run: |
+          touch .env
+          echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" >> .env
+          echo "SPRING_PROFILES_ACTIVE=${{ vars.SPRING_PROFILES_ACTIVE_PRODUCTION }}" >> .env
+          echo "INFRA_PROFILE=${{ vars.INFRA_PROFILE_PRODUCTION}}" >> .env
+      ## deploy to production
+      - name: Deploy to prod
+        run: |
+          sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          sudo chmod +x ./deploy.sh
+          sudo ./deploy.sh ${{ vars.INFRA_PROFILE_PRODUCTION }}
+          sudo docker image prune -af

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -22,13 +22,14 @@ jobs:
       - name: Create .env.development file
         run: |
           touch .env.development
-          echo "BASE_URL=${{secrets.BASE_URL_DEVELOPMENT}}" >> .env.development
+          echo "BASE_URL=${{vars.API_SERVER_URL_DEVELOPMENT}}" >> .env.development
+          echo "DOMAIN_URL=${{vars.WEB_URL_DEVELOPMENT}}" >> .env.development
 
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
           start: yarn start:mocking
-          wait-on: 'http://localhost:3000'
+          wait-on: "http://localhost:3000"
           browser: chrome
           working-directory: ./frontend
         env:


### PR DESCRIPTION
### 🛠️ Issue

- close #579 

### ✅ Tasks
- deploy-prod.yml에서 fe,be build가 끝날 경우 deploy가 실행되도록 변경
- deploy.sh가 실행되도록 추가

### ⏰ Time Difference
- -0.5

### 📝 Note
- fe,be-build가 동시에 실행되며 둘다 끝나야 deploy-prod.yml이 실행되도록 변경했습니다.
