### PR TITLE
[FE] refactor: 글 제목 수정 낙관적 업데이트 구현

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  env: {
+    BASE_URL: 'https://dev.donggle.blog/api',
+  },
   e2e: {
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {

--- a/frontend/cypress/constants/url.ts
+++ b/frontend/cypress/constants/url.ts
@@ -1,0 +1,10 @@
+export const baseURL = Cypress.env('BASE_URL');
+
+export const writingURL = `${baseURL}/writings`;
+export const categoryURL = `${baseURL}/categories`;
+export const trashURL = `${baseURL}/trash`;
+export const memberURL = `${baseURL}/member`;
+export const connectionsURL = `${baseURL}/connections`;
+export const loginURL = `${baseURL}/auth/login`;
+export const authURL = `${baseURL}/auth`;
+export const blogsURL = `${baseURL}/blogs`;

--- a/frontend/cypress/e2e/space-page.cy.ts
+++ b/frontend/cypress/e2e/space-page.cy.ts
@@ -6,7 +6,7 @@ describe('스페이스 페이지 왼쪽 사이드바', () => {
     cy.viewport(1440, 810);
     cy.window().its('localStorage').invoke('setItem', 'accessToken', MOCK_ACCESS_TOKEN);
 
-    cy.visit('/space');
+    cy.visit('/space').wait(1000);
   });
 
   describe('글 가져오기 테스트', () => {
@@ -37,24 +37,26 @@ describe('스페이스 페이지 왼쪽 사이드바', () => {
 
     it('카테고리 이름을 수정할 수 있다.', () => {
       cy.findByLabelText('쿠마 카테고리 메인 화면에 열기').realHover().wait(1000);
+
       cy.findByLabelText('쿠마 카테고리 이름 수정').click().wait(1000);
-      cy.findByLabelText('쿠마 카테고리 이름 수정 입력 창')
-        .focus()
-        .type('쿠쿠마{enter}')
-        .wait(1000);
+      cy.findByLabelText('쿠마 카테고리 이름 수정 입력 창').focus().type('짜잔{enter}').wait(1000);
+
       cy.findByLabelText('쿠마 카테고리 메인 화면에 열기').should('not.exist');
-      cy.findByLabelText('쿠쿠마 카테고리 메인 화면에 열기').should('exist');
+      cy.findByLabelText('쿠마짜잔 카테고리 메인 화면에 열기').should('exist');
     });
 
     it('카테고리를 삭제할 수 있다.', () => {
       cy.findByLabelText('쿠마 카테고리 메인 화면에 열기').realHover().wait(1000);
+
       cy.findByLabelText('쿠마 카테고리 삭제').click().wait(1000);
+
       cy.findByLabelText('쿠마 카테고리 메인 화면에 열기').should('not.exist');
     });
 
     it('글을 삭제하면 휴지통 페이지로 이동한다.', () => {
       cy.findByLabelText('쿠마 카테고리 왼쪽 사이드바에서 열기').click().wait(1000);
       cy.findByLabelText('곰이란 무엇인가?글 메인화면에 열기').realHover().wait(1000);
+
       cy.findByLabelText('곰이란 무엇인가?글 삭제').click();
 
       cy.location('pathname').should('eq', '/space/trash-can');

--- a/frontend/cypress/e2e/writing-page.cy.ts
+++ b/frontend/cypress/e2e/writing-page.cy.ts
@@ -23,12 +23,13 @@ describe('글 페이지', () => {
 
   describe('글 테스트', () => {
     it('글 제목을 변경한다.', () => {
+      cy.findByLabelText('기본 카테고리 왼쪽 사이드바에서 열기').click().wait(1000);
+
       cy.findByLabelText('글 제목 수정').click();
-      cy.findByPlaceholderText('새 제목을 입력해주세요')
-        .focus()
-        .type('새로운 제목이에요{enter}')
-        .wait(1000);
-      cy.findByText('새로운 제목이에요').should('exist');
+      cy.findByPlaceholderText('새 제목을 입력해주세요').focus().type('짜잔{enter}').wait(1000);
+
+      cy.findAllByDisplayValue('동글을 소개합니다 🎉짜잔').should('exist');
+      cy.findAllByDisplayValue('동글을 소개합니다 🎉').should('not.exist');
     });
 
     it('발행 하기 탭이 있다.', () => {

--- a/frontend/cypress/e2e/writing-page.cy.ts
+++ b/frontend/cypress/e2e/writing-page.cy.ts
@@ -28,8 +28,8 @@ describe('글 페이지', () => {
       cy.findByLabelText('글 제목 수정').click();
       cy.findByPlaceholderText('새 제목을 입력해주세요').focus().type('짜잔{enter}').wait(1000);
 
-      cy.findAllByDisplayValue('동글을 소개합니다 🎉짜잔').should('exist');
-      cy.findAllByDisplayValue('동글을 소개합니다 🎉').should('not.exist');
+      cy.findAllByText('동글을 소개합니다 🎉짜잔').should('exist');
+      cy.findAllByText('동글을 소개합니다 🎉').should('not.exist');
     });
 
     it('발행 하기 탭이 있다.', () => {

--- a/frontend/cypress/e2e/writing-page.cy.ts
+++ b/frontend/cypress/e2e/writing-page.cy.ts
@@ -1,4 +1,5 @@
 import { MOCK_ACCESS_TOKEN } from '../../src/mocks/auth';
+import { overrideWritingTitleWithError } from '../overrideHandler/writing';
 
 describe('글 페이지', () => {
   beforeEach(() => {
@@ -50,6 +51,20 @@ describe('글 페이지', () => {
 
     it('발행 하기 탭이 없다.', () => {
       cy.findByLabelText('발행 하기').should('not.exist');
+    });
+  });
+
+  describe('에러 테스트', () => {
+    it('글 제목 변경에 실패한다.', () => {
+      overrideWritingTitleWithError();
+
+      cy.findByLabelText('기본 카테고리 왼쪽 사이드바에서 열기').click().wait(1000);
+
+      cy.findByLabelText('글 제목 수정').click();
+      cy.findByPlaceholderText('새 제목을 입력해주세요').focus().type('짜잔{enter}').wait(1000);
+
+      cy.findAllByText('동글을 소개합니다 🎉').should('exist');
+      cy.findByText('글 제목 수정에 실패했습니다.').should('exist');
     });
   });
 });

--- a/frontend/cypress/overrideHandler/writing.ts
+++ b/frontend/cypress/overrideHandler/writing.ts
@@ -1,0 +1,21 @@
+import { errorCtx } from './../../src/mocks/handlers/utils';
+import { ERROR_RESPONSE } from 'mocks/auth';
+import { writingURL } from '../constants/url';
+
+// 글 수정(이름, 순서): PATCH
+// 글 이름 수정
+export const overrideWritingTitleWithError = () => {
+  cy.window().then((window) => {
+    const { worker, rest } = window.msw;
+
+    worker.use(
+      rest.patch(`${writingURL}/:writingId`, async (req, res, ctx) => {
+        const body = await req.json();
+
+        if ('title' in body) {
+          return res(...errorCtx());
+        }
+      }),
+    );
+  });
+};

--- a/frontend/cypress/tsconfig.json
+++ b/frontend/cypress/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "baseUrl": "../src",
+    "paths": { "*": ["*"] },
     "target": "es5",
     "lib": ["es5", "dom"],
     "types": [

--- a/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
+++ b/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
@@ -25,33 +25,33 @@ const WritingTitle = ({ writingId, categoryId, title, canEditTitle = true }: Pro
   } = useUncontrolledInput();
   const myRef = useRef<HTMLHeadingElement>(null);
   const queryClient = useQueryClient();
+  const toast = useToast();
+
   const { mutate: updateWritingTitle } = useMutation(updateWritingTitleRequest, {
     onSuccess: () => {
       queryClient.invalidateQueries(['writings', writingId]);
       queryClient.invalidateQueries(['writingsInCategory', categoryId]);
     },
+    onError: (error) => {
+      toast.show({ type: 'error', message: getErrorMessage(error) });
+    },
   });
-  const toast = useToast();
 
   const requestChangedName: KeyboardEventHandler<HTMLInputElement> = (e) => {
-    try {
-      if (e.key !== 'Enter') return;
+    if (e.key !== 'Enter') return;
 
-      const writingTitle = e.currentTarget.value.trim();
+    const writingTitle = e.currentTarget.value.trim();
 
-      validateWritingTitle(writingTitle);
+    validateWritingTitle(writingTitle);
 
-      resetInput();
+    resetInput();
 
-      updateWritingTitle({
-        writingId,
-        body: {
-          title: writingTitle,
-        },
-      });
-    } catch (error) {
-      toast.show({ type: 'error', message: getErrorMessage(error) });
-    }
+    updateWritingTitle({
+      writingId,
+      body: {
+        title: writingTitle,
+      },
+    });
   };
 
   useEffect(() => {

--- a/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
+++ b/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
@@ -104,7 +104,7 @@ const WritingTitle = ({ writingId, categoryId, title, canEditTitle = true }: Pro
 
   return (
     <S.TitleWrapper>
-      <>
+      {isInputOpen ? (
         <S.Input
           type='text'
           placeholder='새 제목을 입력해주세요'
@@ -117,12 +117,18 @@ const WritingTitle = ({ writingId, categoryId, title, canEditTitle = true }: Pro
           onKeyUp={requestChangedName}
           disabled={!isInputOpen}
         />
-        {!isInputOpen && canEditTitle && (
-          <S.Button aria-label={'글 제목 수정'} onClick={openInput}>
-            <PencilIcon width={20} height={20} />
-          </S.Button>
-        )}
-      </>
+      ) : (
+        <>
+          <S.Title ref={myRef} tabIndex={0}>
+            {inputTitle}
+          </S.Title>
+          {canEditTitle && (
+            <S.Button aria-label={'글 제목 수정'} onClick={openInput}>
+              <PencilIcon width={20} height={20} />
+            </S.Button>
+          )}
+        </>
+      )}
     </S.TitleWrapper>
   );
 };

--- a/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
+++ b/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
@@ -124,5 +124,9 @@ const S = {
       border: 1px solid ${theme.color.gray1};
       outline: 1px solid ${theme.color.gray1};
     `}
+    ${({ disabled }) => css`
+      background-color: ${disabled ? 'initial' : 'desiredColor'};
+      color: ${disabled ? 'initial' : 'desiredColor'};
+    `}
   `,
 };

--- a/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
+++ b/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
@@ -38,20 +38,24 @@ const WritingTitle = ({ writingId, categoryId, title, canEditTitle = true }: Pro
   });
 
   const requestChangedName: KeyboardEventHandler<HTMLInputElement> = (e) => {
-    if (e.key !== 'Enter') return;
+    try {
+      if (e.key !== 'Enter') return;
 
-    const writingTitle = e.currentTarget.value.trim();
+      const writingTitle = e.currentTarget.value.trim();
 
-    validateWritingTitle(writingTitle);
+      validateWritingTitle(writingTitle);
 
-    resetInput();
+      resetInput();
 
-    updateWritingTitle({
-      writingId,
-      body: {
-        title: writingTitle,
-      },
-    });
+      updateWritingTitle({
+        writingId,
+        body: {
+          title: writingTitle,
+        },
+      });
+    } catch (error) {
+      toast.show({ type: 'error', message: getErrorMessage(error) });
+    }
   };
 
   useEffect(() => {

--- a/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
+++ b/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
@@ -115,7 +115,6 @@ const WritingTitle = ({ writingId, categoryId, title, canEditTitle = true }: Pro
           onBlur={resetInput}
           onKeyDown={escapeRename}
           onKeyUp={requestChangedName}
-          disabled={!isInputOpen}
         />
       ) : (
         <>

--- a/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
+++ b/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
@@ -1,12 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { css, styled } from 'styled-components';
 import { PencilIcon } from 'assets/icons';
-import useUncontrolledInput from 'hooks/@common/useUncontrolledInput';
 import { updateWritingTitle as updateWritingTitleRequest } from 'apis/writings';
 import { KeyboardEventHandler, useEffect, useRef } from 'react';
 import { getErrorMessage } from 'utils/error';
 import { useToast } from 'hooks/@common/useToast';
 import { validateWritingTitle } from 'utils/validators';
+import useControlledInput from 'hooks/@common/useControlledInput';
 
 type Props = {
   writingId: number;
@@ -17,12 +17,14 @@ type Props = {
 
 const WritingTitle = ({ writingId, categoryId, title, canEditTitle = true }: Props) => {
   const {
+    value: inputTitle,
+    setValue: setInputTitle,
     inputRef,
     escapeInput: escapeRename,
     isInputOpen,
     openInput,
     resetInput,
-  } = useUncontrolledInput();
+  } = useControlledInput(title);
   const myRef = useRef<HTMLHeadingElement>(null);
   const queryClient = useQueryClient();
   const toast = useToast();
@@ -64,28 +66,25 @@ const WritingTitle = ({ writingId, categoryId, title, canEditTitle = true }: Pro
 
   return (
     <S.TitleWrapper>
-      {isInputOpen ? (
+      <>
         <S.Input
           type='text'
           placeholder='새 제목을 입력해주세요'
           defaultValue={title}
+          value={inputTitle}
           ref={inputRef}
+          onChange={(e: any) => setInputTitle(e.target.value)}
           onBlur={resetInput}
           onKeyDown={escapeRename}
           onKeyUp={requestChangedName}
+          disabled={!isInputOpen}
         />
-      ) : (
-        <>
-          <S.Title ref={myRef} tabIndex={0}>
-            {title}
-          </S.Title>
-          {canEditTitle && (
-            <S.Button aria-label={'글 제목 수정'} onClick={openInput}>
-              <PencilIcon width={20} height={20} />
-            </S.Button>
-          )}
-        </>
-      )}
+        {!isInputOpen && canEditTitle && (
+          <S.Button aria-label={'글 제목 수정'} onClick={openInput}>
+            <PencilIcon width={20} height={20} />
+          </S.Button>
+        )}
+      </>
     </S.TitleWrapper>
   );
 };

--- a/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
+++ b/frontend/src/components/WritingViewer/WritingTitle/WritingTitle.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { css, styled } from 'styled-components';
 import { PencilIcon } from 'assets/icons';
 import { updateWritingTitle as updateWritingTitleRequest } from 'apis/writings';
-import { KeyboardEventHandler, useEffect, useRef } from 'react';
+import { ChangeEvent, KeyboardEventHandler, useEffect, useRef } from 'react';
 import { getErrorMessage } from 'utils/error';
 import { useToast } from 'hooks/@common/useToast';
 import { validateWritingTitle } from 'utils/validators';
@@ -111,7 +111,7 @@ const WritingTitle = ({ writingId, categoryId, title, canEditTitle = true }: Pro
           defaultValue={title}
           value={inputTitle}
           ref={inputRef}
-          onChange={(e: any) => setInputTitle(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setInputTitle(e.target.value)}
           onBlur={resetInput}
           onKeyDown={escapeRename}
           onKeyUp={requestChangedName}

--- a/frontend/src/hooks/@common/useControlledInput.ts
+++ b/frontend/src/hooks/@common/useControlledInput.ts
@@ -1,0 +1,41 @@
+import { KeyboardEventHandler, useEffect, useRef, useState } from 'react';
+
+const useControlledInput = (defaultValue: string = '') => {
+  const [value, setValue] = useState(defaultValue);
+  const [isError, setIsError] = useState(false);
+  const [isInputOpen, setIsInputOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isInputOpen]);
+
+  const openInput = () => setIsInputOpen(true);
+
+  const resetInput = () => {
+    setIsError(false);
+    setIsInputOpen(false);
+  };
+
+  const escapeInput: KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.key !== 'Escape') return;
+
+    resetInput();
+  };
+
+  return {
+    value,
+    setValue,
+    inputRef,
+    escapeInput,
+    isInputOpen,
+    openInput,
+    resetInput,
+    isError,
+    setIsError,
+  };
+};
+
+export default useControlledInput;

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -1,6 +1,11 @@
 // src/mocks/browser.js
-import { setupWorker } from 'msw';
+import { setupWorker, rest } from 'msw';
 import { handlers } from './handlers';
 
 // This configures a Service Worker with the given request handlers.
 export const worker = setupWorker(...handlers);
+
+window.msw = {
+  worker,
+  rest,
+};

--- a/frontend/src/mocks/data/category.ts
+++ b/frontend/src/mocks/data/category.ts
@@ -169,3 +169,8 @@ export const addRestoredWritings = (writingIds: number[]) => {
     }),
   );
 };
+
+// 기본 카테고리의 첫 글에서 변경
+export const renameWritingTitleIn사이드바기본카테고리 = (newTitle: string) => {
+  writingsIn사이드바기본카테고리.writings[0].title = newTitle;
+};

--- a/frontend/src/mocks/handlers/writing.ts
+++ b/frontend/src/mocks/handlers/writing.ts
@@ -15,6 +15,7 @@ import { errorCtx, jsonCtx, withoutJson } from './utils';
 import { renameWritingTitle, writing, writingProperties } from 'mocks/data/writingPage';
 import { writingTable } from 'mocks/data/writingTablePage';
 import { isConnected } from 'mocks/data/member';
+import { renameWritingTitleIn사이드바기본카테고리 } from 'mocks/data/category';
 
 export const writingHandlers = [
   // 전체 글 조회: GET
@@ -82,6 +83,7 @@ export const writingHandlers = [
     if (hasDefinedField<UpdateWritingTitleArgs['body']>(body, 'title')) {
       if (!isValidAccessToken(req)) return res(...errorCtx(ERROR_RESPONSE, 401));
 
+      renameWritingTitleIn사이드바기본카테고리(body.title);
       renameWritingTitle(body.title);
     }
 

--- a/frontend/src/types/msw.d.ts
+++ b/frontend/src/types/msw.d.ts
@@ -1,0 +1,6 @@
+interface Window {
+  msw: any;
+}
+interface GlobalThis {
+  msw: any;
+}


### PR DESCRIPTION
### 🛠️ Issue

- close #585

### ✅ Tasks
수정 전

https://github.com/woowacourse-teams/2023-dong-gle/assets/33623078/61c6323d-ba74-4e3d-8678-570c465515ce

수정 후

https://github.com/woowacourse-teams/2023-dong-gle/assets/33623078/d9e50cb6-72d3-4f59-a187-2ff692fd4b27

- 글 제목 수정할 때 낙관적 업데이트 적용
- 글 제목 수정 시 깜빡임 현상 해결
- 글 제목 수정 실패 테스트 추가 (msw 오버라이딩 환경설정 및 함수 추가)

### ⏰ Time Difference
- 6 + 6

### 📝 Note
- 
