### PR TITLE
[BE] fix: PublishFacadeServiceTest에서 EntityManager가 mocking 되지 않아 터지는 예외 수정

### DIFF
--- a/backend/src/test/java/org/donggle/backend/application/service/PublishFacadeServiceTest.java
+++ b/backend/src/test/java/org/donggle/backend/application/service/PublishFacadeServiceTest.java
@@ -1,5 +1,6 @@
 package org.donggle.backend.application.service;
 
+import jakarta.persistence.EntityManager;
 import org.donggle.backend.application.service.publish.PublishFacadeService;
 import org.donggle.backend.application.service.publish.PublishService;
 import org.donggle.backend.application.service.request.PublishRequest;
@@ -8,7 +9,6 @@ import org.donggle.backend.domain.blog.Blog;
 import org.donggle.backend.domain.blog.BlogClients;
 import org.donggle.backend.domain.renderer.html.HtmlRenderer;
 import org.donggle.backend.ui.response.PublishResponse;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +21,7 @@ import java.util.List;
 
 import static org.donggle.backend.domain.blog.BlogType.MEDIUM;
 import static org.donggle.backend.support.fix.WritingFixture.writing_ACTIVE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +34,8 @@ class PublishFacadeServiceTest {
     private BlogClients blogClients;
     @Mock
     private PublishService publishService;
+    @Mock
+    private EntityManager entityManager;
 
     @Test
     @DisplayName("블로그 발행 테스트")
@@ -48,8 +51,7 @@ class PublishFacadeServiceTest {
         given(blogClients.publish(publishWritingRequest.blog().getBlogType(), publishRequest, "", "token", "Title 1"))
                 .willReturn(new PublishResponse(LocalDateTime.now(), List.of(), "https://donggle.blog/"));
 
-        //when
-        //then
-        Assertions.assertDoesNotThrow(() -> publishFacadeService.publishWriting(memberId, writingId, MEDIUM, publishRequest));
+        //when & then
+        assertDoesNotThrow(() -> publishFacadeService.publishWriting(memberId, writingId, MEDIUM, publishRequest));
     }
 }


### PR DESCRIPTION
### 🛠️ Issue

- close #600

### ✅ Tasks
- entitymanager mocking
